### PR TITLE
feat: add User entity and repository

### DIFF
--- a/src/main/java/kr/java/java/domain/user/entity/Provider.java
+++ b/src/main/java/kr/java/java/domain/user/entity/Provider.java
@@ -1,0 +1,7 @@
+package kr.java.java.domain.user.entity;
+
+public enum Provider {
+    KAKAO,
+    NAVER,
+    GOOGLE
+}

--- a/src/main/java/kr/java/java/domain/user/entity/Role.java
+++ b/src/main/java/kr/java/java/domain/user/entity/Role.java
@@ -1,0 +1,6 @@
+package kr.java.java.domain.user.entity;
+
+public enum Role {
+    SPACE_OWNER,  // 공간주
+    MAKER         // 메이커
+}

--- a/src/main/java/kr/java/java/domain/user/entity/User.java
+++ b/src/main/java/kr/java/java/domain/user/entity/User.java
@@ -1,9 +1,7 @@
 package kr.java.java.domain.user.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.AccessLevel;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -13,6 +11,8 @@ import java.time.LocalDateTime;
 @Table(name = "user")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class User {
 
     @Id
@@ -29,14 +29,16 @@ public class User {
     @Column(name = "profile_image_url", columnDefinition = "TEXT")
     private String profileImageUrl;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "provider", length = 20)
-    private String provider;
+    private Provider provider;
 
     @Column(name = "provider_id", length = 255)
     private String providerId;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false, length = 20)
-    private String role;
+    private Role role;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
@@ -45,4 +47,18 @@ public class User {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    // 비즈니스 메서드
+    public void updateProfile(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public boolean isSpaceOwner() {
+        return this.role == Role.SPACE_OWNER;
+    }
+
+    public boolean isMaker() {
+        return this.role == Role.MAKER;
+    }
 }

--- a/src/main/java/kr/java/java/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/java/java/domain/user/repository/UserRepository.java
@@ -1,9 +1,25 @@
 package kr.java.java.domain.user.repository;
 
+import kr.java.java.domain.user.entity.Provider;
+import kr.java.java.domain.user.entity.Role;
 import kr.java.java.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface UserRepository extends JpaRepository<User,Long> {
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    // 이메일로 유저 찾기
+    Optional<User> findByEmail(String email);
+
+    // Provider와 ProviderId로 유저 찾기 (OAuth 로그인용)
+    Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
+
+    // 이메일 중복 체크
+    boolean existsByEmail(String email);
+
+    // 권한 검증
+    boolean existsByIdAndRole(Long id, Role role);
 }


### PR DESCRIPTION
## 🔍 What
- User 엔티티 및 Provider, Role Enum 구현
- UserRepository 인터페이스 구현 (OAuth 로그인용 메서드 포함)
- 소셜 로그인 기반 사용자 관리를 위한 도메인 기본 구조 구축

## 🧪 How to test
- User 엔티티 필드 확인 (email, nickname, provider, role 등)
- Provider Enum 값 확인 (KAKAO, NAVER, GOOGLE)
- Role Enum 값 확인 (SPACE_OWNER, MAKER)
- UserRepository 메서드 확인 (findByProviderAndProviderId 등)

## 🔗 Issue
- Closes: #16

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?