### PR TITLE
[Feat] 알림 내역 저장

### DIFF
--- a/src/main/java/kr/java/java/domain/notification/controller/NotificationController.java
+++ b/src/main/java/kr/java/java/domain/notification/controller/NotificationController.java
@@ -1,0 +1,52 @@
+package kr.java.java.domain.notification.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.java.java.domain.notification.dto.NotificationResponse;
+import kr.java.java.domain.notification.enums.NotificationType;
+import kr.java.java.domain.notification.service.NotificationService;
+import kr.java.java.domain.user.entity.User;
+import kr.java.java.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/piece/notifications")
+@RequiredArgsConstructor
+@Tag(name = "Notification", description = "알림 API")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final UserRepository userRepository;
+
+    //to do: SSE 연결
+
+    @Operation(summary = "알림 내역 조회", description = "특정 사용자의 모든 알림 내역을 조회합니다.")
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<NotificationResponse>> getNotifications(@PathVariable Long userId) {
+        return ResponseEntity.ok(notificationService.getNotifications(userId));
+    }
+
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 상태로 변경합니다.")
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<String> readNotification(@PathVariable Long notificationId) {
+        notificationService.readNotification(notificationId);
+        return ResponseEntity.ok("Read notification");
+    }
+
+//    //테스트용 알림 생성
+//    @PostMapping("/test/{userId}")
+//    public ResponseEntity<String> createTestNotification(@PathVariable Long userId,
+//                                                         @RequestParam String content,
+//                                                         @RequestParam String relatedUrl,
+//                                                         @RequestParam NotificationType type) {
+//        User user = userRepository.findById(userId)
+//                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+//
+//        notificationService.createNotification(user, content, relatedUrl, type);
+//        return ResponseEntity.ok("Notification created");
+//    }
+}

--- a/src/main/java/kr/java/java/domain/notification/controller/NotificationController.java
+++ b/src/main/java/kr/java/java/domain/notification/controller/NotificationController.java
@@ -3,11 +3,8 @@ package kr.java.java.domain.notification.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.java.java.domain.notification.dto.NotificationResponse;
-import kr.java.java.domain.notification.enums.NotificationType;
 import kr.java.java.domain.notification.exception.NotificationNotFoundException;
 import kr.java.java.domain.notification.service.NotificationService;
-import kr.java.java.domain.user.entity.User;
-import kr.java.java.domain.user.exception.UserNotFoundException;
 import kr.java.java.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,17 +29,12 @@ public class NotificationController {
     @GetMapping("/{userId}")
     public ResponseEntity<List<NotificationResponse>> getNotifications(@PathVariable Long userId) {
         log.info("[알림 api] 알림 내역 조회, 유저 ID: {}", userId);
-        try {
-            if (!userRepository.existsById(userId)) {
-                throw new UserNotFoundException(userId);
-            }
-            List<NotificationResponse> notifications = notificationService.getNotifications(userId);
-            log.info("[알림 api] {} 조회 성공, 유저 ID: {}", notifications.size(), userId);
-            return ResponseEntity.ok(notifications);
-        } catch (UserNotFoundException e) {
-            log.error("[알림 api] 해당 유저를 찾을 수 없음: {}", e.getMessage());
-            throw e;
-        }
+//        if (!userRepository.existsById(userId)) {
+//            throw new UserNotFoundException(userId);
+//        }
+        List<NotificationResponse> notifications = notificationService.getNotifications(userId);
+        log.info("[알림 api] {} 조회 성공, 유저 ID: {}", notifications.size(), userId);
+        return ResponseEntity.ok(notifications);
     }
 
     @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 상태로 변경합니다.")

--- a/src/main/java/kr/java/java/domain/notification/controller/NotificationController.java
+++ b/src/main/java/kr/java/java/domain/notification/controller/NotificationController.java
@@ -4,15 +4,19 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.java.java.domain.notification.dto.NotificationResponse;
 import kr.java.java.domain.notification.enums.NotificationType;
+import kr.java.java.domain.notification.exception.NotificationNotFoundException;
 import kr.java.java.domain.notification.service.NotificationService;
 import kr.java.java.domain.user.entity.User;
+import kr.java.java.domain.user.exception.UserNotFoundException;
 import kr.java.java.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/piece/notifications")
 @RequiredArgsConstructor
@@ -27,24 +31,42 @@ public class NotificationController {
     @Operation(summary = "알림 내역 조회", description = "특정 사용자의 모든 알림 내역을 조회합니다.")
     @GetMapping("/{userId}")
     public ResponseEntity<List<NotificationResponse>> getNotifications(@PathVariable Long userId) {
-        return ResponseEntity.ok(notificationService.getNotifications(userId));
+        log.info("[알림 api] 알림 내역 조회, 유저 ID: {}", userId);
+        try {
+            if (!userRepository.existsById(userId)) {
+                throw new UserNotFoundException(userId);
+            }
+            List<NotificationResponse> notifications = notificationService.getNotifications(userId);
+            log.info("[알림 api] {} 조회 성공, 유저 ID: {}", notifications.size(), userId);
+            return ResponseEntity.ok(notifications);
+        } catch (UserNotFoundException e) {
+            log.error("[알림 api] 해당 유저를 찾을 수 없음: {}", e.getMessage());
+            throw e;
+        }
     }
 
     @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 상태로 변경합니다.")
     @PatchMapping("/{notificationId}/read")
     public ResponseEntity<String> readNotification(@PathVariable Long notificationId) {
-        notificationService.readNotification(notificationId);
-        return ResponseEntity.ok("Read notification");
+        log.info("[알림 api]: 알림 읽음 처리 - {}", notificationId);
+        try {
+            notificationService.readNotification(notificationId);
+            log.info("[알림 api]: 알림 읽음 처리 성공 - {}", notificationId);
+            return ResponseEntity.ok("Notification read");
+        } catch (NotificationNotFoundException e) {
+            log.error("[알림 api]: 해당 알림 찾을 수 없음 - {}", e.getMessage());
+            throw e;
+        }
     }
 
-//    //테스트용 알림 생성
+//    //테스트 알림 생성
 //    @PostMapping("/test/{userId}")
 //    public ResponseEntity<String> createTestNotification(@PathVariable Long userId,
 //                                                         @RequestParam String content,
 //                                                         @RequestParam String relatedUrl,
 //                                                         @RequestParam NotificationType type) {
 //        User user = userRepository.findById(userId)
-//                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+//                .orElseThrow(() -> new UserNotFoundException(userId));
 //
 //        notificationService.createNotification(user, content, relatedUrl, type);
 //        return ResponseEntity.ok("Notification created");

--- a/src/main/java/kr/java/java/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/kr/java/java/domain/notification/dto/NotificationResponse.java
@@ -1,0 +1,34 @@
+package kr.java.java.domain.notification.dto;
+
+import kr.java.java.domain.notification.entity.Notification;
+import kr.java.java.domain.notification.enums.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationResponse {
+    private Long id;
+    private String content;
+    private String relatedUrl;
+    private boolean isRead;
+    private NotificationType notificationType;
+    private LocalDateTime createdAt;
+
+    public static NotificationResponse from(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .content(notification.getContent())
+                .relatedUrl(notification.getRelatedUrl())
+                .isRead(notification.isRead())
+                .notificationType(notification.getNotificationType())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/kr/java/java/domain/notification/entity/Notification.java
+++ b/src/main/java/kr/java/java/domain/notification/entity/Notification.java
@@ -1,0 +1,61 @@
+package kr.java.java.domain.notification.entity;
+
+import jakarta.persistence.*;
+import kr.java.java.domain.notification.enums.NotificationType;
+import kr.java.java.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notifications")
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User receiver;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(name = "related_url")
+    private String relatedUrl;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType notificationType;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Notification(User receiver, String content, String relatedUrl, NotificationType notificationType) {
+        this.receiver = receiver;
+        this.content = content;
+        this.relatedUrl = relatedUrl;
+        this.notificationType = notificationType;
+        this.isRead = false;
+    }
+
+    public void read() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/kr/java/java/domain/notification/enums/NotificationType.java
+++ b/src/main/java/kr/java/java/domain/notification/enums/NotificationType.java
@@ -1,0 +1,20 @@
+package kr.java.java.domain.notification.enums;
+
+public enum NotificationType {
+    MATCHING("매칭신청"),
+    COMMENT("댓글"),
+    CONTRACT_END("계약종료"),
+    MATCHING_COMPLETE("매칭완료"),
+    MATCHING_REJECT("매칭거절"),
+    ETC("기타");
+
+    private final String description;
+
+    NotificationType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/kr/java/java/domain/notification/exception/NotificationExceptionHandler.java
+++ b/src/main/java/kr/java/java/domain/notification/exception/NotificationExceptionHandler.java
@@ -1,0 +1,21 @@
+package kr.java.java.domain.notification.exception;
+
+import kr.java.java.domain.user.exception.UserNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class NotificationExceptionHandler {
+
+    @ExceptionHandler(NotificationNotFoundException.class)
+    public ResponseEntity<String> handleNotificationNotFoundException(NotificationNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<String> handleUserNotFoundException(UserNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+}

--- a/src/main/java/kr/java/java/domain/notification/exception/NotificationExceptionHandler.java
+++ b/src/main/java/kr/java/java/domain/notification/exception/NotificationExceptionHandler.java
@@ -1,6 +1,5 @@
 package kr.java.java.domain.notification.exception;
 
-import kr.java.java.domain.user.exception.UserNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,8 +13,8 @@ public class NotificationExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
 
-    @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<String> handleUserNotFoundException(UserNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-    }
+//    @ExceptionHandler(UserNotFoundException.class)
+//    public ResponseEntity<String> handleUserNotFoundException(UserNotFoundException e) {
+//        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+//    }
 }

--- a/src/main/java/kr/java/java/domain/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/kr/java/java/domain/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.java.java.domain.notification.exception;
+
+public class NotificationNotFoundException extends RuntimeException {
+    public NotificationNotFoundException(Long notificationId) {
+        super("Notification not found with id: " + notificationId);
+    }
+}

--- a/src/main/java/kr/java/java/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/kr/java/java/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package kr.java.java.domain.notification.repository;
+
+import kr.java.java.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findAllByReceiverIdOrderByCreatedAt(Long receiverId);
+}

--- a/src/main/java/kr/java/java/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/java/java/domain/notification/service/NotificationService.java
@@ -1,0 +1,46 @@
+package kr.java.java.domain.notification.service;
+
+import kr.java.java.domain.notification.dto.NotificationResponse;
+import kr.java.java.domain.notification.entity.Notification;
+import kr.java.java.domain.notification.enums.NotificationType;
+import kr.java.java.domain.notification.exception.NotificationNotFoundException;
+import kr.java.java.domain.notification.repository.NotificationRepository;
+import kr.java.java.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public Notification createNotification(User receiver, String content, String relatedUrl, NotificationType notificationType) {
+        Notification notification = Notification.builder()
+                .receiver(receiver)
+                .content(content)
+                .relatedUrl(relatedUrl)
+                .notificationType(notificationType)
+                .build();
+        return notificationRepository.save(notification);
+    }
+
+    public List<NotificationResponse> getNotifications(Long userId) {
+        return notificationRepository.findAllByReceiverIdOrderByCreatedAt(userId).stream()
+                .map(NotificationResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void readNotification(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationNotFoundException(notificationId));
+        notification.read();
+    }
+}

--- a/src/main/java/kr/java/java/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/java/java/domain/notification/service/NotificationService.java
@@ -7,12 +7,14 @@ import kr.java.java.domain.notification.exception.NotificationNotFoundException;
 import kr.java.java.domain.notification.repository.NotificationRepository;
 import kr.java.java.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -28,10 +30,12 @@ public class NotificationService {
                 .relatedUrl(relatedUrl)
                 .notificationType(notificationType)
                 .build();
+        log.info("[알림] 알림 생성");
         return notificationRepository.save(notification);
     }
 
     public List<NotificationResponse> getNotifications(Long userId) {
+        log.info("[알림] 알림 조회");
         return notificationRepository.findAllByReceiverIdOrderByCreatedAt(userId).stream()
                 .map(NotificationResponse::from)
                 .collect(Collectors.toList());
@@ -39,6 +43,7 @@ public class NotificationService {
 
     @Transactional
     public void readNotification(Long notificationId) {
+        log.info("[알림] 알림 읽음 처리");
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(() -> new NotificationNotFoundException(notificationId));
         notification.read();

--- a/src/main/java/kr/java/java/global/config/SecurityConfig.java
+++ b/src/main/java/kr/java/java/global/config/SecurityConfig.java
@@ -14,8 +14,9 @@ public class SecurityConfig{
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/piece/space/**", "/piece/notifications/**", "/piece/users/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 );
         return http.build();
     }


### PR DESCRIPTION
## 🔍 What
- 알림 저장, 사용자 ID에 대한 알림내역 조회, 알림 읽음처리 구현
- 로그 작성 및 예외처리

## 🧪 How to test
- postman을 활용해 엔드포인트를 테스트
- User와 notification에 대한 더미데이터가 존재해야 기능 테스트가 가능

## 🔗 Issue
- Closes: #9
---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?