### PR TITLE
[Feat] 소셜 로그인 (#8)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/java/java/domain/auth/controller/AuthController.java
+++ b/src/main/java/kr/java/java/domain/auth/controller/AuthController.java
@@ -1,0 +1,37 @@
+package kr.java.java.domain.auth.controller;
+
+import kr.java.java.domain.auth.dto.TokenResponse;
+import kr.java.java.domain.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/piece/auths")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    // Refresh Token으로 Access Token 재발급
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@RequestHeader("Authorization") String refreshToken) {
+        // "Bearer " 제거
+        String token = refreshToken.replace("Bearer ", "");
+        TokenResponse response = authService.refreshAccessToken(token);
+        return ResponseEntity.ok(response);
+    }
+
+    // 소셜 로그인 테스트
+    @GetMapping("/login-success")
+    public ResponseEntity<String> loginSuccess(@RequestParam Long userId) {
+        return ResponseEntity.ok("소셜 로그인 성공! 유저 ID: " + userId);
+    }
+
+    // 로그아웃
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("User-Id") Long userId) {
+        authService.logout(userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/kr/java/java/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/kr/java/java/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,12 @@
+package kr.java.java.domain.auth.dto;
+
+public class LoginRequest {
+
+    private String code;
+    private String role;
+
+    public LoginRequest(String code, String role) {
+        this.code = code;
+        this.role = role;
+    }
+}

--- a/src/main/java/kr/java/java/domain/auth/dto/OAuth2UserInfo.java
+++ b/src/main/java/kr/java/java/domain/auth/dto/OAuth2UserInfo.java
@@ -1,0 +1,70 @@
+package kr.java.java.domain.auth.dto;
+
+import lombok.Getter;
+import java.util.Map;
+
+@Getter
+public class OAuth2UserInfo {
+
+    private final String providerId;
+    private final String provider;
+    private final String email;
+    private final String name;
+    private final String profileImage;
+
+    private OAuth2UserInfo(String providerId, String provider, String email, String name, String profileImage) {
+        this.providerId = providerId;
+        this.provider = provider;
+        this.email = email;
+        this.name = name;
+        this.profileImage = profileImage;
+    }
+
+    // Factory 메서드 -> Provider에 맞는 UserInfo 자동 생성
+    public static OAuth2UserInfo of(String provider, Map<String, Object> attributes) {
+        return switch (provider.toLowerCase()) {
+            case "kakao" -> ofKakao(attributes);
+            case "naver" -> ofNaver(attributes);
+            case "google" -> ofGoogle(attributes);
+            default -> throw new IllegalArgumentException("지원하지 않는 Provider: " + provider);
+        };
+    }
+
+    // 카카오 정보 추출
+    private static OAuth2UserInfo ofKakao(Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+
+        return new OAuth2UserInfo(
+                String.valueOf(attributes.get("id")),
+                "KAKAO",
+                kakaoAccount != null ? (String) kakaoAccount.get("email") : null,
+                properties != null ? (String) properties.get("nickname") : null,
+                properties != null ? (String) properties.get("profile_image") : null
+        );
+    }
+
+    // 네이버 정보 추출
+    private static OAuth2UserInfo ofNaver(Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        return new OAuth2UserInfo(
+                response != null ? (String) response.get("id") : null,
+                "NAVER",
+                response != null ? (String) response.get("email") : null,
+                response != null ? (String) response.get("name") : null,
+                response != null ? (String) response.get("profile_image") : null
+        );
+    }
+
+    // 구글 정보 추출
+    private static OAuth2UserInfo ofGoogle(Map<String, Object> attributes) {
+        return new OAuth2UserInfo(
+                (String) attributes.get("sub"),
+                "GOOGLE",
+                (String) attributes.get("email"),
+                (String) attributes.get("name"),
+                (String) attributes.get("picture")
+        );
+    }
+}

--- a/src/main/java/kr/java/java/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/kr/java/java/domain/auth/dto/TokenResponse.java
@@ -1,0 +1,27 @@
+package kr.java.java.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType = "Bearer";
+    private Long expiresIn;
+
+    public static TokenResponse of(String accessToken, String refreshToken, Long expiresIn) {
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .tokenType("Bearer")
+                .expiresIn(expiresIn)
+                .build();
+    }
+}

--- a/src/main/java/kr/java/java/domain/auth/dto/UserResponse.java
+++ b/src/main/java/kr/java/java/domain/auth/dto/UserResponse.java
@@ -1,0 +1,35 @@
+package kr.java.java.domain.auth.dto;
+
+import kr.java.java.domain.user.entity.Provider;
+import kr.java.java.domain.user.entity.Role;
+import kr.java.java.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserResponse {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private String profileImageUrl;
+    private Provider provider;
+    private Role role;
+
+    // User 엔티티를 DTO로 변환
+    public static UserResponse from(User user) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .provider(user.getProvider())
+                .role(user.getRole())
+                .build();
+    }
+}

--- a/src/main/java/kr/java/java/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/kr/java/java/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,44 @@
+package kr.java.java.domain.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_token")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "token", nullable = false, unique = true, length = 500)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    // 토큰 만료 여부 확인
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    // 토큰 갱신
+    public void updateToken(String newToken, LocalDateTime newExpiresAt) {
+        this.token = newToken;
+        this.expiresAt = newExpiresAt;
+    }
+}

--- a/src/main/java/kr/java/java/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/java/java/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package kr.java.java.domain.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+
+        String token = resolveToken(request);
+
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+
+            Long userId = jwtTokenProvider.getUserIdFromToken(token);
+
+
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    userId, null, Collections.singletonList(new SimpleGrantedAuthority("ROLE_MAKER")));
+
+            // SecurityContext에 인증 정보 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/kr/java/java/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/java/java/domain/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,83 @@
+package kr.java.java.domain.auth.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpiration;
+    private final long refreshTokenExpiration;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-expiration}") long accessTokenExpiration,
+            @Value("${jwt.refresh-token-expiration}") long refreshTokenExpiration
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.refreshTokenExpiration = refreshTokenExpiration;
+    }
+
+    // Access Token 생성
+    public String createAccessToken(Long userId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + accessTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // Refresh Token 생성
+    public String createRefreshToken(Long userId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + refreshTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // 토큰에서 userId 추출
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    // 토큰 유효성 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    // Access Token 만료 시간 반환 (초 단위)
+    public long getAccessTokenExpirationInSeconds() {
+        return accessTokenExpiration / 1000;
+    }
+}

--- a/src/main/java/kr/java/java/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/kr/java/java/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,23 @@
+package kr.java.java.domain.auth.repository;
+
+import kr.java.java.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    // userId로 RefreshToken 찾기
+    Optional<RefreshToken> findByUserId(Long userId);
+
+    // token 문자열로 찾기
+    Optional<RefreshToken> findByToken(String token);
+
+    // userId로 삭제 (로그아웃 시)
+    void deleteByUserId(Long userId);
+
+    // token으로 존재 여부 확인
+    boolean existsByToken(String token);
+}

--- a/src/main/java/kr/java/java/domain/auth/security/CustomOAuth2User.java
+++ b/src/main/java/kr/java/java/domain/auth/security/CustomOAuth2User.java
@@ -1,0 +1,44 @@
+package kr.java.java.domain.auth.security;
+
+import kr.java.java.domain.user.entity.Role;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+    private final Long userId;  // DB의 User ID
+    private final String email;
+    private final Role role;
+    private final String provider;
+    private final Map<String, Object> attributes;
+
+    public CustomOAuth2User(Long userId, String email, Role role, String provider, Map<String, Object> attributes) {
+        this.userId = userId;
+        this.email = email;
+        this.role = role;
+        this.provider = provider;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    @Override
+    public String getName() {
+        return provider + "_" + email;
+    }
+}

--- a/src/main/java/kr/java/java/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/java/java/domain/auth/service/AuthService.java
@@ -1,0 +1,145 @@
+package kr.java.java.domain.auth.service;
+
+import kr.java.java.domain.auth.dto.LoginRequest;
+import kr.java.java.domain.auth.dto.OAuth2UserInfo;
+import kr.java.java.domain.auth.dto.TokenResponse;
+import kr.java.java.domain.auth.entity.RefreshToken;
+import kr.java.java.domain.auth.jwt.JwtTokenProvider;
+import kr.java.java.domain.auth.repository.RefreshTokenRepository;
+import kr.java.java.domain.user.entity.Provider;
+import kr.java.java.domain.user.entity.Role;
+import kr.java.java.domain.user.entity.User;
+import kr.java.java.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // OAuth2 로그인 처리
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) {
+        OAuth2User oauth2User = super.loadUser(userRequest);
+
+        // Provider 정보 추출
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        Map<String, Object> attributes = oauth2User.getAttributes();
+
+        // OAuth2UserInfo 생성
+        OAuth2UserInfo userInfo = OAuth2UserInfo.of(registrationId, attributes);
+
+        // 사용자 조회 또는 생성
+        User user = saveOrUpdate(userInfo);
+
+        return new kr.java.java.domain.auth.security.CustomOAuth2User(
+                user.getId(),
+                user.getEmail(),
+                user.getRole(),
+                registrationId.toUpperCase(),
+                attributes
+        );
+    }
+
+    // 사용자 저장 또는 업데이트
+    @Transactional
+    public User saveOrUpdate(OAuth2UserInfo userInfo) {
+        Provider provider = Provider.valueOf(userInfo.getProvider());
+
+        User user = userRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
+                .map(entity -> {
+                    // 기존 사용자 정보 업데이트
+                    entity.updateProfile(userInfo.getName(), userInfo.getProfileImage());
+                    return entity;
+                })
+                .orElseGet(() -> {
+                    // 신규 사용자 생성 (기본 MAKER 역할)
+                    return User.builder()
+                            .email(userInfo.getEmail())
+                            .nickname(userInfo.getName())
+                            .profileImageUrl(userInfo.getProfileImage())
+                            .provider(provider)
+                            .providerId(userInfo.getProviderId())
+                            .role(Role.MAKER)  // 기본값
+                            .build();
+                });
+
+        return userRepository.save(user);
+    }
+
+    // JWT 토큰 발급
+    @Transactional
+    public TokenResponse issueToken(Long userId) {
+        // Access Token 생성
+        String accessToken = jwtTokenProvider.createAccessToken(userId);
+
+        // Refresh Token 생성
+        String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+        // Refresh Token DB 저장 (기존 토큰 있으면 업데이트)
+        refreshTokenRepository.findByUserId(userId)
+                .ifPresentOrElse(
+                        token -> token.updateToken(refreshToken, LocalDateTime.now().plusDays(7)),
+                        () -> {
+                            RefreshToken newToken = RefreshToken.builder()
+                                    .userId(userId)
+                                    .token(refreshToken)
+                                    .expiresAt(LocalDateTime.now().plusDays(7))
+                                    .build();
+                            refreshTokenRepository.save(newToken);
+                        }
+                );
+
+        return TokenResponse.of(
+                accessToken,
+                refreshToken,
+                jwtTokenProvider.getAccessTokenExpirationInSeconds()
+        );
+    }
+
+    // Refresh Token으로 Access Token 재발급
+    @Transactional
+    public TokenResponse refreshAccessToken(String refreshToken) {
+        // Refresh Token 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+        }
+
+        // DB에서 Refresh Token 조회
+        RefreshToken token = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Refresh Token입니다."));
+
+        // 만료 확인
+        if (token.isExpired()) {
+            throw new IllegalArgumentException("만료된 Refresh Token입니다.");
+        }
+
+        // 새 Access Token 발급
+        String newAccessToken = jwtTokenProvider.createAccessToken(token.getUserId());
+
+        return TokenResponse.of(
+                newAccessToken,
+                refreshToken,  // Refresh Token은 그대로
+                jwtTokenProvider.getAccessTokenExpirationInSeconds()
+        );
+    }
+
+    // 로그아웃 (Refresh Token 삭제)
+    @Transactional
+    public void logout(Long userId) {
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+}

--- a/src/main/java/kr/java/java/global/config/SecurityConfig.java
+++ b/src/main/java/kr/java/java/global/config/SecurityConfig.java
@@ -1,0 +1,94 @@
+package kr.java.java.global.config;
+
+import kr.java.java.domain.auth.entity.RefreshToken;
+import kr.java.java.domain.auth.jwt.JwtAuthenticationFilter;
+import kr.java.java.domain.auth.jwt.JwtTokenProvider;
+import kr.java.java.domain.auth.repository.RefreshTokenRepository;
+import kr.java.java.domain.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.LocalDateTime;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        // OAuth2 로그인 관련 URL 허용
+                        .requestMatchers("/api/auth/**", "/login/**", "/oauth2/**", "/login-success", "/piece/spaces/**","/piece/auths/**").permitAll()                        // 나머지는 인증 필요
+                        .anyRequest().authenticated()
+                )
+
+                .addFilterBefore(jwtAuthenticationFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class)
+
+                // OAuth2 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo ->
+                                userInfo.userService(authService)
+                        )
+                        .successHandler((request, response, authentication) -> {
+
+                            // 로그인 성공 시 처리
+                            kr.java.java.domain.auth.security.CustomOAuth2User oauth2User =
+                                    (kr.java.java.domain.auth.security.CustomOAuth2User) authentication.getPrincipal();
+                            // TODO: JWT 발급 후 프론트로 리다이렉트
+                            //response.sendRedirect("http://localhost:8080/user/naver/login?userId=" + oauth2User.getUserId());
+                            // })
+
+                            Long userId = oauth2User.getUserId();
+
+                            // JWT 토큰 생성
+                            String accessToken = jwtTokenProvider.createAccessToken(userId);
+                            String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+                            // 만료 시간 설정 (예: 7일)
+                            LocalDateTime expiryDate = LocalDateTime.now().plusDays(7);
+
+                            // Refresh Token DB 저장 로직
+                            // 기존 토큰이 있으면 업데이트하고, 없으면 새로 빌드합니다.
+                            RefreshToken tokenEntity = refreshTokenRepository.findByUserId(userId)
+                                    .map(existingToken -> {
+                                        existingToken.updateToken(refreshToken, expiryDate);
+                                        return existingToken;
+                                    })
+                                    .orElseGet(() -> RefreshToken.builder()
+                                            .userId(userId)
+                                            .token(refreshToken)
+                                            .expiresAt(expiryDate)
+                                            .build());
+
+                            refreshTokenRepository.save(tokenEntity);
+
+                            // 최종 리다이렉트 (발급된 accessToken을 파라미터로 전달)
+                            String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/piece/auths/login-success")
+                                    .queryParam("accessToken", accessToken)
+                                    .queryParam("userId", userId)
+                                    .build().toUriString();
+
+                            response.sendRedirect(targetUrl);                  })
+                );
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
## 🔍 What
- 소셜 로그인(OAuth2) 연동: 네이버, 카카오, 구글 사용자 정보 추출 및 로그인을 처리하는 AuthService 구현
- JWT 토큰 시스템 구축: JwtTokenProvider를 통한 Access/Refresh Token 발급 및 검증 로직 구현
- 보안 필터 및 설정: JwtAuthenticationFilter 적용 및 SecurityConfig 내 stateless 인증 체계 구축

## 🧪 How to test
- JWT 발급 확인: 소셜 로그인 성공 시 /login-success로 리다이렉트되며 URL 파라미터로 토큰이 전달되는지 확인
- DB 저장 확인: 로그인 성공 시 RefreshToken 엔티티가 DB에 정상적으로 생성/업데이트되는지 확인
- 인증 필터 동작: 발급된 토큰을 Authorization 헤더에 담아 요청 시 시큐리티 컨텍스트에 인증 정보가 설정되는지 확인

## 🔗 Issue
- Closes: #8 

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [x] 최소 1명의 리뷰를 받았나요?