### PR TITLE
[Feat] 리뷰 수정

### DIFF
--- a/src/main/java/kr/java/java/domain/review/controller/ReviewController.java
+++ b/src/main/java/kr/java/java/domain/review/controller/ReviewController.java
@@ -73,7 +73,7 @@ public class ReviewController {
     }
 
     // 리뷰 수정 API
-    @PutMapping("/{reviewId}")
+    @PatchMapping("/{reviewId}")
     public ResponseEntity<String> updateReview(
             @PathVariable Long reviewId,
             @RequestBody @Valid ReviewUpdateRequest request

--- a/src/main/java/kr/java/java/domain/review/controller/ReviewController.java
+++ b/src/main/java/kr/java/java/domain/review/controller/ReviewController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import kr.java.java.domain.review.dto.ReviewCreateRequest;
 import kr.java.java.domain.review.dto.ReviewDeleteRequest;
 import kr.java.java.domain.review.dto.ReviewResponse;
+import kr.java.java.domain.review.dto.ReviewUpdateRequest;
 import kr.java.java.domain.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -60,7 +61,7 @@ public class ReviewController {
     @DeleteMapping("/{reviewId}")
     public ResponseEntity<String> deleteReview(
             @PathVariable Long reviewId,
-            @RequestBody ReviewDeleteRequest request // Record 사용
+            @RequestBody ReviewDeleteRequest request
     ) {
         log.info("DELETE /piece/reviews/{} 요청 발생 - 요청자 ID: {}", reviewId, request.userId());
 
@@ -69,5 +70,20 @@ public class ReviewController {
         log.info("리뷰 삭제 완료 응답 반환 - 삭제된 reviewId: {}", reviewId);
 
         return ResponseEntity.ok("리뷰가 성공적으로 삭제되었습니다.");
+    }
+
+    // 리뷰 수정 API
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<String> updateReview(
+            @PathVariable Long reviewId,
+            @RequestBody @Valid ReviewUpdateRequest request
+    ) {
+        log.info("PUT /piece/reviews/{} 요청 발생 - 요청자 ID: {}", reviewId, request.userId());
+
+        reviewService.updateReview(reviewId, request);
+
+        log.info("리뷰 수정 완료 응답 반환 - reviewId: {}", reviewId);
+
+        return ResponseEntity.ok("리뷰가 성공적으로 수정되었습니다.");
     }
 }

--- a/src/main/java/kr/java/java/domain/review/dto/ReviewUpdateRequest.java
+++ b/src/main/java/kr/java/java/domain/review/dto/ReviewUpdateRequest.java
@@ -1,0 +1,16 @@
+package kr.java.java.domain.review.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record ReviewUpdateRequest(
+        Long userId,
+
+        @NotBlank(message = "리뷰 내용 필수")
+        String content,
+
+        @Min(value = 1, message = "별점은 1점 이상")
+        @Max(value = 5, message = "별점은 5점 이하")
+        Integer rating
+) {}

--- a/src/main/java/kr/java/java/domain/review/dto/ReviewUpdateRequest.java
+++ b/src/main/java/kr/java/java/domain/review/dto/ReviewUpdateRequest.java
@@ -2,12 +2,10 @@ package kr.java.java.domain.review.dto;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 
 public record ReviewUpdateRequest(
         Long userId,
 
-        @NotBlank(message = "리뷰 내용 필수")
         String content,
 
         @Min(value = 1, message = "별점은 1점 이상")

--- a/src/main/java/kr/java/java/domain/review/entity/Review.java
+++ b/src/main/java/kr/java/java/domain/review/entity/Review.java
@@ -51,7 +51,12 @@ public class Review {
     }
 
     public void updateReview(Integer rating, String content) {
-        this.rating = rating;
-        this.content = content;
+        if (rating != null) {
+            this.rating = rating;
+        }
+
+        if (content != null && !content.isBlank()) {
+            this.content = content;
+        }
     }
 }

--- a/src/main/java/kr/java/java/domain/review/service/ReviewService.java
+++ b/src/main/java/kr/java/java/domain/review/service/ReviewService.java
@@ -2,6 +2,7 @@ package kr.java.java.domain.review.service;
 
 import kr.java.java.domain.review.dto.ReviewCreateRequest;
 import kr.java.java.domain.review.dto.ReviewResponse;
+import kr.java.java.domain.review.dto.ReviewUpdateRequest;
 import kr.java.java.domain.review.entity.Review;
 import kr.java.java.domain.review.exception.*;
 import kr.java.java.domain.review.repository.ReviewRepository;
@@ -112,5 +113,28 @@ public class ReviewService {
         // 3. 리뷰 삭제
         reviewRepository.delete(review);
         log.info("리뷰 삭제 완료 - reviewId: {}", reviewId);
+    }
+
+    @Transactional
+    public void updateReview(Long reviewId, ReviewUpdateRequest request) {
+        log.info("리뷰 수정 시작 - reviewId: {}, userId: {}", reviewId, request.userId());
+
+        // 1. 리뷰 조회
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> {
+                    log.error("리뷰 수정 실패 - 존재하지 않는 리뷰 ID: {}", reviewId);
+                    return new ReviewNotFoundException("해당 리뷰를 찾을 수 없습니다.");
+                });
+
+        // 2. 작성자 권한 검증
+        if (!review.getUser().getId().equals(request.userId())) {
+            log.warn("리뷰 수정 권한 없음 - 작성자: {}, 요청자: {}", review.getUser().getId(), request.userId());
+            throw new ReviewAccessDeniedException("본인이 작성한 리뷰만 수정할 수 있습니다.");
+        }
+
+        // 3. 리뷰 수정
+        review.updateReview(request.rating(), request.content());
+
+        log.info("리뷰 수정 완료 - reviewId: {}", reviewId);
     }
 }


### PR DESCRIPTION
리뷰 데이터 수정 API 구현

## 🔍 What
- 리뷰 데이터 수정 API 구현

## 🧪 How to test
- 포스트맨에서 PATCH http://localhost:8080/piece/reviews/{reviews_id}로 테스트
- 테스트하기 전 유저, 공간, 매칭테이블에 테스트용 임시 유저, 공간, 매칭 데이터가 있어야 리뷰가 작성됨
리뷰 작성/수정 테스트 예시
{
"matchingId": 1,
"userId": 1,
"rating": 5,
"content": "리뷰 생성(수정) 테스트"
}

## 🔗 Issue
- Closes: #38 

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [x] 최소 1명의 리뷰를 받았나요?