### PR TITLE
[Feat] 서버 측 SSE 연결 및 subscribe 구현

### DIFF
--- a/src/main/java/kr/java/java/domain/notification/controller/NotificationController.java
+++ b/src/main/java/kr/java/java/domain/notification/controller/NotificationController.java
@@ -3,13 +3,18 @@ package kr.java.java.domain.notification.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.java.java.domain.notification.dto.NotificationResponse;
+import kr.java.java.domain.notification.enums.NotificationType;
 import kr.java.java.domain.notification.exception.NotificationNotFoundException;
+import kr.java.java.domain.notification.exception.UserNotFoundException;
 import kr.java.java.domain.notification.service.NotificationService;
+import kr.java.java.domain.user.entity.User;
 import kr.java.java.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 
@@ -23,15 +28,24 @@ public class NotificationController {
     private final NotificationService notificationService;
     private final UserRepository userRepository;
 
-    //to do: SSE 연결
+    @Operation(summary = "알림 구독", description = "알림 구독을 위해 SSE 연결을 실행합니다.")
+    @GetMapping(value = "/subscribe/{userId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@PathVariable Long userId,
+                                @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
+        log.info("[알림 api] SSE 구독 요청, 유저 ID: {}", userId);
+        if (!userRepository.existsById(userId)) {
+            throw new UserNotFoundException(userId);
+        }
+        return notificationService.subscribe(userId, lastEventId);
+    }
 
     @Operation(summary = "알림 내역 조회", description = "특정 사용자의 모든 알림 내역을 조회합니다.")
     @GetMapping("/{userId}")
     public ResponseEntity<List<NotificationResponse>> getNotifications(@PathVariable Long userId) {
         log.info("[알림 api] 알림 내역 조회, 유저 ID: {}", userId);
-//        if (!userRepository.existsById(userId)) {
-//            throw new UserNotFoundException(userId);
-//        }
+        if (!userRepository.existsById(userId)) {
+            throw new UserNotFoundException(userId);
+        }
         List<NotificationResponse> notifications = notificationService.getNotifications(userId);
         log.info("[알림 api] {} 조회 성공, 유저 ID: {}", notifications.size(), userId);
         return ResponseEntity.ok(notifications);
@@ -51,16 +65,25 @@ public class NotificationController {
         }
     }
 
-//    //테스트 알림 생성
+//    //테스트용
 //    @PostMapping("/test/{userId}")
 //    public ResponseEntity<String> createTestNotification(@PathVariable Long userId,
 //                                                         @RequestParam String content,
 //                                                         @RequestParam String relatedUrl,
 //                                                         @RequestParam NotificationType type) {
+//        log.info("[알림 api] 테스트 알림 생성 요청, 유저 ID: {}", userId);
 //        User user = userRepository.findById(userId)
 //                .orElseThrow(() -> new UserNotFoundException(userId));
 //
 //        notificationService.createNotification(user, content, relatedUrl, type);
 //        return ResponseEntity.ok("Notification created");
 //    }
+
+//@PostMapping("/test-send/{userId}")
+//    public String testSend(@PathVariable Long userId) {
+//        User user = userRepository.findById(userId)
+//                .orElseThrow(() -> new UserNotFoundException(userId));
+//        notificationService.sendNotification(user,NotificationType.MATCHING,"테스트 : 매칭 신청이 왔습니다.","/matchings/1");
+//    return "알림 발송 성공 (User ID: " + userId + ")";
+//}
 }

--- a/src/main/java/kr/java/java/domain/notification/entity/Notification.java
+++ b/src/main/java/kr/java/java/domain/notification/entity/Notification.java
@@ -27,7 +27,7 @@ public class Notification {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
-    private User receiver;
+    private User userId;
 
     @Column(nullable = false)
     private String content;
@@ -47,8 +47,8 @@ public class Notification {
     private LocalDateTime createdAt;
 
     @Builder
-    public Notification(User receiver, String content, String relatedUrl, NotificationType notificationType) {
-        this.receiver = receiver;
+    public Notification(User userId, String content, String relatedUrl, NotificationType notificationType) {
+        this.userId = userId;
         this.content = content;
         this.relatedUrl = relatedUrl;
         this.notificationType = notificationType;

--- a/src/main/java/kr/java/java/domain/notification/exception/NotificationExceptionHandler.java
+++ b/src/main/java/kr/java/java/domain/notification/exception/NotificationExceptionHandler.java
@@ -13,8 +13,13 @@ public class NotificationExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
 
-//    @ExceptionHandler(UserNotFoundException.class)
-//    public ResponseEntity<String> handleUserNotFoundException(UserNotFoundException e) {
-//        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-//    }
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<String> handleUserNotFoundException(UserNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(NotificationSendException.class)
+    public ResponseEntity<String> handleNotificationSendException(NotificationSendException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+    }
 }

--- a/src/main/java/kr/java/java/domain/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/kr/java/java/domain/notification/exception/NotificationNotFoundException.java
@@ -2,6 +2,6 @@ package kr.java.java.domain.notification.exception;
 
 public class NotificationNotFoundException extends RuntimeException {
     public NotificationNotFoundException(Long notificationId) {
-        super("Notification not found with id: " + notificationId);
+        super("[Error] 알림을 찾을 수 없습니다. 알림 ID: " + notificationId);
     }
 }

--- a/src/main/java/kr/java/java/domain/notification/exception/NotificationSendException.java
+++ b/src/main/java/kr/java/java/domain/notification/exception/NotificationSendException.java
@@ -1,0 +1,7 @@
+package kr.java.java.domain.notification.exception;
+
+public class NotificationSendException extends RuntimeException {
+    public NotificationSendException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/kr/java/java/domain/notification/exception/UserNotFoundException.java
+++ b/src/main/java/kr/java/java/domain/notification/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.java.java.domain.notification.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(Long userID) {
+        super("[Error] 유저를 찾을 수 없습니다. 유저 ID: " + userID);
+    }
+}

--- a/src/main/java/kr/java/java/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/kr/java/java/domain/notification/repository/EmitterRepository.java
@@ -1,0 +1,25 @@
+package kr.java.java.domain.notification.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public interface EmitterRepository {
+
+    SseEmitter saveEmitter(String emitterId, SseEmitter sseEmitter);
+
+    void saveEventCache(String eventCacheId, Object event);
+
+    Map<String, SseEmitter> findAllEmitterStartWithUserId(String userId);
+
+    Map<String, Object> findAllEventCacheStartWithUserId(String userId);
+
+    void deleteEmitterById(String emitterId);
+
+    void deleteAllEmitterStartWithUserId(String userId);
+
+    void deleteAllEventCacheStartWithUserId(String userId);
+}

--- a/src/main/java/kr/java/java/domain/notification/repository/InMemoryEmitterRepository.java
+++ b/src/main/java/kr/java/java/domain/notification/repository/InMemoryEmitterRepository.java
@@ -1,0 +1,67 @@
+package kr.java.java.domain.notification.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+public class InMemoryEmitterRepository implements EmitterRepository {
+
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCaches = new ConcurrentHashMap<>();
+
+    @Override
+    public SseEmitter saveEmitter(String emitterId, SseEmitter sseEmitter) {
+        emitters.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+    @Override
+    public void saveEventCache(String eventCacheId, Object event) {
+        eventCaches.put(eventCacheId, event);
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllEmitterStartWithUserId(String userId) {
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(userId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public Map<String, Object> findAllEventCacheStartWithUserId(String userId) {
+        return eventCaches.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(userId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void deleteEmitterById(String emitterId) {
+        emitters.remove(emitterId);
+    }
+
+    @Override
+    public void deleteAllEmitterStartWithUserId(String userId) {
+        emitters.forEach(
+                (key, emitter) -> {
+                    if (key.startsWith(userId)) {
+                        emitters.remove(key);
+                    }
+                }
+        );
+    }
+
+    @Override
+    public void deleteAllEventCacheStartWithUserId(String userId) {
+        eventCaches.forEach(
+                (key, event) -> {
+                    if (key.startsWith(userId)) {
+                        eventCaches.remove(key);
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/kr/java/java/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/kr/java/java/domain/notification/repository/NotificationRepository.java
@@ -1,10 +1,11 @@
 package kr.java.java.domain.notification.repository;
 
 import kr.java.java.domain.notification.entity.Notification;
+import kr.java.java.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    List<Notification> findAllByReceiverIdOrderByCreatedAt(Long receiverId);
+    List<Notification> findAllByUserId_IdOrderByCreatedAtDesc(Long user);
 }

--- a/src/main/java/kr/java/java/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/java/java/domain/notification/service/NotificationService.java
@@ -4,14 +4,19 @@ import kr.java.java.domain.notification.dto.NotificationResponse;
 import kr.java.java.domain.notification.entity.Notification;
 import kr.java.java.domain.notification.enums.NotificationType;
 import kr.java.java.domain.notification.exception.NotificationNotFoundException;
+import kr.java.java.domain.notification.exception.NotificationSendException;
+import kr.java.java.domain.notification.repository.EmitterRepository;
 import kr.java.java.domain.notification.repository.NotificationRepository;
 import kr.java.java.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -21,22 +26,83 @@ import java.util.stream.Collectors;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final EmitterRepository emitterRepository;
+
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60; // 60분
+
+    public SseEmitter subscribe(Long userId, String lastEventId) {
+        String emitterId = userId + "_" + System.currentTimeMillis();
+        SseEmitter emitter = emitterRepository.saveEmitter(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
+
+        emitter.onCompletion(() -> {
+            log.info("[알림] SSE onCompletion callback");
+            emitterRepository.deleteEmitterById(emitterId);
+        });
+        emitter.onTimeout(() -> {
+            log.info("[알림] SSE onTimeout callback");
+            emitterRepository.deleteEmitterById(emitterId);
+        });
+        emitter.onError((e) -> {
+            log.info("[알림] SSE onError callback");
+            emitterRepository.deleteEmitterById(emitterId);
+        });
+
+        sendEventToClient(emitter, emitterId, "connect", "SSE 연결되었습니다. [userId: " + userId + "]");
+
+
+        if (!lastEventId.isEmpty()) {
+            Map<String, Object> events = emitterRepository.findAllEventCacheStartWithUserId(String.valueOf(userId));
+            events.entrySet().stream()
+                    .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                    .forEach(entry -> sendEventToClient(emitter, entry.getKey(), "notification", entry.getValue()));
+        }
+
+        log.info("[알림] SSE 연결 완료, userId:" + userId);
+        return emitter;
+    }
 
     @Transactional
-    public Notification createNotification(User receiver, String content, String relatedUrl, NotificationType notificationType) {
-        Notification notification = Notification.builder()
-                .receiver(receiver)
+    public void sendNotification(User receiver, NotificationType notificationType, String content, String relatedUrl) {
+
+        Notification notification = notificationRepository.save(createNotificationEntity(receiver, content, relatedUrl, notificationType));
+        String receiverId = String.valueOf(receiver.getId());
+        Map<String, SseEmitter> emitters = emitterRepository.findAllEmitterStartWithUserId(receiverId);
+
+        emitters.forEach(
+                (key, emitter) -> {
+                    emitterRepository.saveEventCache(key, notification);
+
+                    sendEventToClient(emitter,key,"notification",NotificationResponse.from(notification));
+                }
+        );
+    }
+
+    private Notification createNotificationEntity(User receiver, String content, String relatedUrl, NotificationType notificationType) {
+        return Notification.builder()
+                .userId(receiver)
                 .content(content)
                 .relatedUrl(relatedUrl)
                 .notificationType(notificationType)
                 .build();
-        log.info("[알림] 알림 생성");
-        return notificationRepository.save(notification);
+    }
+
+    private void sendEventToClient(SseEmitter emitter, String emitterId, String eventName, Object sendData) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(emitterId)
+                    .name(eventName)
+                    .data(sendData));
+            log.info("[알림] 이벤트 전송, eventName:" + eventName);
+        } catch (IOException exception) {
+            emitterRepository.deleteEmitterById(emitterId);
+            log.error("[알림] SSE 연결 오류", exception);
+            // throw new NotificationSendException("알림 전송 실패", exception);
+        }
     }
 
     public List<NotificationResponse> getNotifications(Long userId) {
         log.info("[알림] 알림 조회");
-        return notificationRepository.findAllByReceiverIdOrderByCreatedAt(userId).stream()
+        return notificationRepository.findAllByUserId_IdOrderByCreatedAtDesc(userId).stream()
                 .map(NotificationResponse::from)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/kr/java/java/global/config/SecurityConfig.java
+++ b/src/main/java/kr/java/java/global/config/SecurityConfig.java
@@ -35,7 +35,10 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/piece/spaces/**").permitAll()
+                        .requestMatchers("/piece/portfolios/**").permitAll()
                         .requestMatchers("/piece/reviews/**").permitAll()
+                        .requestMatchers("/piece/matchings/**").permitAll()
+                        .requestMatchers("/piece/notifications/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         // OAuth2 로그인 관련 URL 허용
                         .requestMatchers("/api/auth/**", "/login/**", "/oauth2/**", "/login-success", "/piece/spaces/**","/piece/auths/**").permitAll()                        // 나머지는 인증 필요

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,3 +5,30 @@ spring:
     url: ${DB_URL}
     username: ${DB_USER}
     password: ${DB_PW}
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope: profile, email
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: ${JWT_ACCESS_EXPIRATION}
+  refresh-token-expiration: ${JWT_REFRESH_EXPIRATION}
+
+logging:
+  level:
+    kr.java.java: INFO
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE


### PR DESCRIPTION
## 🔍 What
- SSE 구독 API 및 EmitterRepository 구현
- 이벤트 발생 시 알림 전송 로직 구현

## 🧪 How to test
- 브라우저 개발자 도구(Console)에서 EventSource를 이용해 구독 API(/piece/notifications/subscribe/{테스트용 유저 id})에 연결한 뒤, 연결 성공 로그를 확인.
- NotificationController의 testSend 메서드를 주석 해제한 다음 postman에서 POST 요청을 보내 브라우저 콘솔 창에 테스트 알림 데이터가 출력되는지 확인

## 🔗 Issue
- Closes: #22

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [x] 최소 1명의 리뷰를 받았나요?