### PR TITLE
[Feat] 랜덤 닉네임 및 프로필 이미지 생성 및 핸들러 추가

### DIFF
--- a/src/main/java/kr/java/java/domain/auth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/kr/java/java/domain/auth/handler/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,46 @@
+package kr.java.java.domain.auth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.java.java.domain.auth.exception.AuthErrorCode;
+import kr.java.java.domain.auth.exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * OAuth2 로그인 실패 시 처리하는 핸들러
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                       HttpServletResponse response,
+                                       AuthenticationException exception) throws IOException {
+
+        log.error("OAuth2 로그인 실패: {}", exception.getMessage(), exception);
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", AuthErrorCode.UNAUTHORIZED.name());
+        result.put("message", "소셜 로그인에 실패했습니다: " + exception.getMessage());
+
+        response.getWriter().write(objectMapper.writeValueAsString(result));
+    }
+}

--- a/src/main/java/kr/java/java/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/java/java/domain/auth/service/AuthService.java
@@ -9,6 +9,8 @@ import kr.java.java.domain.user.entity.Provider;
 import kr.java.java.domain.user.entity.Role;
 import kr.java.java.domain.user.entity.User;
 import kr.java.java.domain.user.repository.UserRepository;
+import kr.java.java.global.util.ProfileImageUrlGenerator;
+import kr.java.java.global.util.RandomNicknameGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -63,21 +65,22 @@ public class AuthService extends DefaultOAuth2UserService {
         }
 
         User user = userRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
-                .map(entity -> {
-                    entity.updateProfile(
-                            userInfo.getName() != null ? userInfo.getName() : entity.getNickname(),
-                            userInfo.getProfileImage() != null ? userInfo.getProfileImage() : entity.getProfileImageUrl()
-                    );
+                .map(entity -> { //
+
                     return entity;
                 })
                 .orElseGet(() -> {
+
+                    UUID uuid = UUID.randomUUID();
+
                     if (userInfo.getName() == null || userInfo.getName().isEmpty()) {
                         throw new AuthException(AuthErrorCode.MISSING_REQUIRED_FIELD);
                     }
                     return User.builder()
+                            .uuid(uuid)
                             .email(userInfo.getEmail())
-                            .nickname(userInfo.getName())
-                            .profileImageUrl(userInfo.getProfileImage())
+                            .nickname(RandomNicknameGenerator.generate())
+                            .profileImageUrl(ProfileImageUrlGenerator.generate(uuid)) // boring avatars
                             .provider(provider)
                             .providerId(userInfo.getProviderId())
                             .role(Role.USER)

--- a/src/main/java/kr/java/java/global/util/ProfileImageUrlGenerator.java
+++ b/src/main/java/kr/java/java/global/util/ProfileImageUrlGenerator.java
@@ -1,0 +1,12 @@
+package kr.java.java.global.util;
+
+import java.util.UUID;
+
+public class ProfileImageUrlGenerator {
+
+    private static final String BORING_AVATARS_BASE_URL = "https://source.boringavatars.com/beam/120/";
+
+    public static String generate(UUID uuid) {
+        return BORING_AVATARS_BASE_URL + uuid.toString();
+    }
+}

--- a/src/main/java/kr/java/java/global/util/RandomNicknameGenerator.java
+++ b/src/main/java/kr/java/java/global/util/RandomNicknameGenerator.java
@@ -1,0 +1,37 @@
+package kr.java.java.global.util;
+
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.Arrays;
+
+public class RandomNicknameGenerator {
+
+    private static final SecureRandom random = new SecureRandom();
+    // 형용사 + 명사 조합
+    // 형용사 리스트
+    private static final List<String> ADJECTIVES = Arrays.asList(
+            "춤추는", "귀여운", "신나는", "졸린", "배고픈",
+            "행복한", "슬픈", "화난", "웃는", "반짝이는",
+            "날아다니는", "뛰어다니는", "느긋한", "바쁜", "여유로운",
+            "똑똑한", "멋진", "사랑스러운", "용감한", "겁많은",
+            "장난꾸러기", "조용한", "시끄러운", "활발한", "차분한",
+            "신비로운", "강력한", "부드러운", "날렵한", "둥근"
+    );
+
+    // 명사 리스트
+    private static final List<String> NOUNS = Arrays.asList(
+            "다람쥐", "토끼", "로봇", "펭귄", "고양이",
+            "강아지", "판다", "코알라", "여우", "늑대",
+            "사자", "호랑이", "곰", "햄스터", "거북이",
+            "돌고래", "고래", "상어", "물개", "수달",
+            "앵무새", "부엉이", "독수리", "참새", "까마귀",
+            "용", "유니콘", "피카츄", "치타", "기린"
+    );
+
+    public static String generate() {
+        String adjective = ADJECTIVES.get(random.nextInt(ADJECTIVES.size()));
+        String noun = NOUNS.get(random.nextInt(NOUNS.size()));
+
+        return adjective + noun;
+    }
+}


### PR DESCRIPTION
## 🔍 What
- 소셜 로그인 시 랜덤 프로필 이미지, 랜덤 닉네임 생성 후 부여
- 로그인 실패 핸들러 추가

## 🧪 How to test
- 소셜 로그인 시 유저에게 랜덤 프로필 이미지, 랜덤 닉네임이 부여됩니다.

## 🔗 Issue
- Closes: #43 

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?