### PR TITLE
[Feat] 유저 이미지 업로드 및 삭제

### DIFF
--- a/src/main/java/kr/java/java/domain/image/enums/ImageDomain.java
+++ b/src/main/java/kr/java/java/domain/image/enums/ImageDomain.java
@@ -1,0 +1,15 @@
+package kr.java.java.domain.image.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageDomain {
+    USER("user"),
+    SPACE("space"),
+    REVIEW("review"),
+    PORTFOLIO("portfolio");
+
+    private final String dirName;
+}

--- a/src/main/java/kr/java/java/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/kr/java/java/domain/image/exception/ImageErrorCode.java
@@ -1,0 +1,18 @@
+package kr.java.java.domain.image.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ImageErrorCode {
+    DB_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "DB에 해당 이미지가 존재하지 않습니다."),
+    S3_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "외부 저장소에 해당 이미지가 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ImageErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/kr/java/java/domain/image/exception/ImageException.java
+++ b/src/main/java/kr/java/java/domain/image/exception/ImageException.java
@@ -1,0 +1,13 @@
+package kr.java.java.domain.image.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ImageException extends RuntimeException {
+    private final ImageErrorCode errorCode;
+
+    public ImageException(ImageErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kr/java/java/domain/image/service/ImageService.java
+++ b/src/main/java/kr/java/java/domain/image/service/ImageService.java
@@ -3,6 +3,8 @@ package kr.java.java.domain.image.service;
 import kr.java.java.domain.image.entity.Image;
 import kr.java.java.domain.image.enums.ImageDomain;
 import kr.java.java.domain.image.enums.TargetType;
+import kr.java.java.domain.image.exception.ImageErrorCode;
+import kr.java.java.domain.image.exception.ImageException;
 import kr.java.java.domain.image.repository.ImageRepository;
 import kr.java.java.domain.portfolio.entity.Portfolio;
 import kr.java.java.domain.portfolio.exception.NotFoundPortfolioException;
@@ -21,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
@@ -112,5 +115,24 @@ public class ImageService {
                 .build(), RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
 
         return String.format("%s/storage/v1/object/public/%s/%s", supabaseUrl, bucket, fileName);
+    }
+
+    public void deleteProfileImage(String fileUrl){
+        if (fileUrl == null || fileUrl.isEmpty()) return;
+
+        String fileName = extractFileName(fileUrl);
+
+        try{
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(fileName)
+                    .build());
+        } catch (Exception e){
+            throw new ImageException(ImageErrorCode.S3_IMAGE_NOT_FOUND);
+        }
+    }
+
+    private String extractFileName(String url) {
+        return url.substring(url.lastIndexOf("/") + 1);
     }
 }

--- a/src/main/java/kr/java/java/domain/image/service/ImageService.java
+++ b/src/main/java/kr/java/java/domain/image/service/ImageService.java
@@ -1,6 +1,7 @@
 package kr.java.java.domain.image.service;
 
 import kr.java.java.domain.image.entity.Image;
+import kr.java.java.domain.image.enums.ImageDomain;
 import kr.java.java.domain.image.enums.TargetType;
 import kr.java.java.domain.image.repository.ImageRepository;
 import kr.java.java.domain.portfolio.entity.Portfolio;
@@ -12,6 +13,7 @@ import kr.java.java.domain.review.repository.ReviewRepository;
 import kr.java.java.domain.space.entity.Space;
 import kr.java.java.domain.space.exception.NotFoundSpaceException;
 import kr.java.java.domain.space.repository.SpaceRepository;
+import kr.java.java.domain.user.repository.UserRepository;
 import kr.java.java.global.util.FileUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,6 +34,7 @@ public class ImageService {
     private final ReviewRepository reviewRepository;
     private final SpaceRepository spaceRepository;
     private final PortfolioRepository portfolioRepository;
+    private final UserRepository userRepository;
 
     @Value("${supabase.storage.bucket}")
     private String bucket;
@@ -93,5 +96,21 @@ public class ImageService {
                         .build();
             }
         };
+    }
+
+    public String uploadProfileImage(MultipartFile file) throws IOException {
+        if(!file.isEmpty()){
+            return null;
+        }
+
+        String fileName = ImageDomain.USER.getDirName() + "/" + FileUtil.createFileName(file.getOriginalFilename());
+
+        s3Client.putObject(PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .contentType(file.getContentType())
+                .build(), RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+        return String.format("%s/storage/v1/object/public/%s/%s", supabaseUrl, bucket, fileName);
     }
 }


### PR DESCRIPTION
## 🔍 What
- file을 받아 'user/UUID 파일명.확장자'의 이름으로 S3에 저장 및 저장된 이미지의 URL 반환
- 이미지의 URL을 받아 S3에서 제거

## 🧪 How to test
- S3 연동 후 User service 동작에 사용하여 테스트

## 🔗 Issue
- Closes: #102 
---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [x] 최소 1명의 리뷰를 받았나요?