### PR TITLE
[Feat] 매칭 대기 중 원하는 시작 날짜를 넘은 경우 거절

### DIFF
--- a/src/main/java/kr/java/java/domain/matching/entity/Matching.java
+++ b/src/main/java/kr/java/java/domain/matching/entity/Matching.java
@@ -91,4 +91,8 @@ public class Matching {
     public void completeMatch(){
         this.status = MatchStatus.COMPLETED;
     }
+
+    public void rejectMatch(){
+        this.status = MatchStatus.REJECTED;
+    }
 }

--- a/src/main/java/kr/java/java/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/kr/java/java/domain/matching/repository/MatchingRepository.java
@@ -94,5 +94,17 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
             "JOIN FETCH m.user " +
             "JOIN FETCH m.receiver " +
             "WHERE m.endDate < :today AND m.status = :status")
-    List<Matching> findExpiredMatchingsWithUser(LocalDate today, MatchStatus status);
+    List<Matching> findExpiredMatchingsWithUser(
+            @Param("today") LocalDate today,
+            @Param("status") MatchStatus status
+    );
+
+    @Query("SELECT m FROM Matching m " +
+            "JOIN FETCH m.user " +
+            "JOIN FETCH m.receiver " +
+            "WHERE m.startDate < :today AND m.status = :status")
+    List<Matching> findOverdueWaitingMatchings(
+            @Param("today") LocalDate today,
+            @Param("status") MatchStatus status
+    );
 }

--- a/src/main/java/kr/java/java/domain/matching/scheduler/MatchingStatusScheduler.java
+++ b/src/main/java/kr/java/java/domain/matching/scheduler/MatchingStatusScheduler.java
@@ -13,5 +13,6 @@ public class MatchingStatusScheduler {
     @Scheduled(cron = "0 0 0 * * *")
     public void updateMatchingStatus(){
         matchingService.processExpiredMatchings();
+        matchingService.processOverdueWaitingMatchings();
     }
 }

--- a/src/main/java/kr/java/java/domain/matching/service/MatchingService.java
+++ b/src/main/java/kr/java/java/domain/matching/service/MatchingService.java
@@ -256,6 +256,30 @@ public class MatchingService {
                 log.error("[매칭 상태 변경] 실패: ID={}, 사유={}", matching.getId(), e.getMessage());
             }
         }
-        log.info("만료 매칭 처리 완료");
+    }
+
+    @Transactional
+    public void processOverdueWaitingMatchings() {
+        LocalDate today = LocalDate.now();
+
+        List<Matching> overdueMatchings = matchingRepository.findOverdueWaitingMatchings(today, MatchStatus.WAITING);
+
+        log.info("총 {}건의 만료 대상 매칭 발견", overdueMatchings.size());
+
+        for(Matching matching : overdueMatchings){
+            try{
+                matching.rejectMatch();
+
+                log.info("[매칭 거절] ID: {}, 발신자: {}, 수신자: {}",
+                        matching.getId(),
+                        matching.getUser().getNickname(),
+                        matching.getReceiver().getNickname());
+
+                // TODO: 발신자에게 알림 전송
+
+            } catch(Exception e){
+                log.error("[자동 거절 실패] ID: {}, 사유: {}", matching.getId(), e.getMessage());
+            }
+        }
     }
 }


### PR DESCRIPTION
## 🔍 What
- 매칭 대기 중 원하는 시작 날짜를 넘은 경우 거절

## 🧪 How to test
- status가 WAITING인 매칭의 원하는 시작 날짜를 현재보다 이전의 날짜로 등록
- matching/scheduler/MatchingStatusScheduler의 Scheduled 어노테이션을 @scheduled(fixedRate = 10000)로 변경하여 10초마다의 테스트 가능

## 🔗 Issue
- Closes: #106 
---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [x] 최소 1명의 리뷰를 받았나요?