### PR TITLE
[Feat] 회원 프로필 이미지 처리

### DIFF
--- a/src/main/java/kr/java/java/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/java/java/domain/auth/service/AuthService.java
@@ -80,7 +80,7 @@ public class AuthService extends DefaultOAuth2UserService {
                             .uuid(uuid)
                             .email(userInfo.getEmail())
                             .nickname(RandomNicknameGenerator.generate())
-                            .profileImageUrl(ProfileImageUrlGenerator.generate(uuid)) // boring avatars
+                            .profileImageUrl(ProfileImageUrlGenerator.generate(uuid))
                             .provider(provider)
                             .providerId(userInfo.getProviderId())
                             .role(Role.USER)

--- a/src/main/java/kr/java/java/domain/user/controller/MypageController.java
+++ b/src/main/java/kr/java/java/domain/user/controller/MypageController.java
@@ -6,9 +6,13 @@ import kr.java.java.domain.user.dto.MypageResponse;
 import kr.java.java.domain.user.dto.ProfileUpdateRequest;
 import kr.java.java.domain.user.service.MypageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 
 @RestController
@@ -25,11 +29,22 @@ public class MypageController {
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/profile")
+    @PutMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<MypageResponse> updateProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Valid @RequestBody ProfileUpdateRequest request) {
-        MypageResponse response = mypageService.updateProfile(userDetails.getUuid(), request);
+            @RequestPart(value = "request", required = false) @Valid ProfileUpdateRequest request,
+            @RequestPart(value = "file", required = false) MultipartFile file
+    ) throws IOException {
+
+        MypageResponse response = mypageService.updateProfile(userDetails.getUuid(), request, file);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/profile/image")
+    public ResponseEntity<MypageResponse> deleteProfileImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        MypageResponse response = mypageService.deleteProfileImage(userDetails.getUuid());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/kr/java/java/domain/user/entity/User.java
+++ b/src/main/java/kr/java/java/domain/user/entity/User.java
@@ -81,4 +81,11 @@ public class User {
     public boolean isUser() {
         return this.role == Role.USER;
     }
+
+    public boolean isCustomImage(String imageUrl) {
+        if (imageUrl == null || imageUrl.isEmpty()) {
+            return false;
+        }
+        return !imageUrl.startsWith("https://api.dicebear.com/");
+    }
 }

--- a/src/main/java/kr/java/java/domain/user/service/MypageService.java
+++ b/src/main/java/kr/java/java/domain/user/service/MypageService.java
@@ -1,6 +1,12 @@
 package kr.java.java.domain.user.service;
 
 
+import kr.java.java.domain.auth.service.RefreshTokenService;
+import kr.java.java.domain.comment.repository.CommentRepository;
+import kr.java.java.domain.favorite.entity.Favorite;
+import kr.java.java.domain.favorite.repository.FavoriteRepository;
+import kr.java.java.domain.image.service.ImageService;
+import kr.java.java.domain.matching.repository.MatchingRepository;
 import kr.java.java.domain.portfolio.repository.PortfolioRepository;
 import kr.java.java.domain.review.repository.ReviewRepository;
 import kr.java.java.domain.space.repository.SpaceRepository;
@@ -10,14 +16,21 @@ import kr.java.java.domain.user.entity.User;
 import kr.java.java.domain.user.exception.UserErrorCode;
 import kr.java.java.domain.user.exception.UserException;
 import kr.java.java.domain.user.repository.UserRepository;
+import kr.java.java.global.util.ProfileImageUrlGenerator;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class MypageService {
 
@@ -25,6 +38,11 @@ public class MypageService {
     private final SpaceRepository spaceRepository;
     private final PortfolioRepository portfolioRepository;
     private final ReviewRepository reviewRepository;
+    private final CommentRepository commentRepository;
+    private final MatchingRepository matchingRepository;
+    private final FavoriteRepository favoriteRepository;
+    private final RefreshTokenService refreshTokenService;
+    private final ImageService imageService;
 
     // 마이페이지 메인
     public MypageResponse getMypage(UUID uuid) {
@@ -44,21 +62,46 @@ public class MypageService {
     }
 
     @Transactional
-    public MypageResponse updateProfile(UUID uuid, ProfileUpdateRequest request) {
+    public MypageResponse updateProfile(UUID uuid, ProfileUpdateRequest request, MultipartFile file) throws IOException {
         User user = userRepository.findByUuid(uuid)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        // 닉네임 중복 체크 (본인 닉네임 제외)
-        if (!user.getNickname().equals(request.getNickname())) {
-            if (userRepository.existsByNickname(request.getNickname())) {
-                throw new UserException(UserErrorCode.DUPLICATE_NICKNAME);
+        String newNickname = user.getNickname();
+        if (request != null && request.getNickname() != null && !request.getNickname().isBlank()) {
+            if (!user.getNickname().equals(request.getNickname())) {
+                if (userRepository.existsByNickname(request.getNickname())) {
+                    throw new UserException(UserErrorCode.DUPLICATE_NICKNAME);
+                }
+                newNickname = request.getNickname();
             }
         }
 
-        // 프로필 업데이트
-        user.updateProfile(request.getNickname(), request.getProfileImageUrl());
+        String newImageUrl = user.getProfileImageUrl();
+        if (file != null && !file.isEmpty()) {
+            // 기존 이미지가 S3 이미지라면 삭제
+            if (user.isCustomImage(user.getProfileImageUrl())) {
+                imageService.deleteProfileImage(user.getProfileImageUrl());
+            }
+            // 새 이미지 업로드
+            newImageUrl = imageService.uploadProfileImage(file);
+        }
 
-        // 업데이트된 정보 반환
+        user.updateProfile(newNickname, newImageUrl);
+
+        return getMypage(uuid);
+    }
+    @Transactional
+    public MypageResponse deleteProfileImage(UUID uuid) {
+        User user = userRepository.findByUuid(uuid)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        if (user.isCustomImage(user.getProfileImageUrl())) {
+            imageService.deleteProfileImage(user.getProfileImageUrl());
+        }
+
+        String defaultImageUrl = ProfileImageUrlGenerator.generate(user.getUuid());
+        user.updateProfile(user.getNickname(), defaultImageUrl);
+
         return getMypage(uuid);
     }
 }

--- a/src/main/java/kr/java/java/global/util/ProfileImageUrlGenerator.java
+++ b/src/main/java/kr/java/java/global/util/ProfileImageUrlGenerator.java
@@ -1,12 +1,21 @@
 package kr.java.java.global.util;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 public class ProfileImageUrlGenerator {
 
-    private static final String BORING_AVATARS_BASE_URL = "https://source.boringavatars.com/beam/120/";
+    private static final String BASE_URL = "https://api.dicebear.com/9.x/thumbs/svg";
 
     public static String generate(UUID uuid) {
-        return BORING_AVATARS_BASE_URL + uuid.toString();
+        if (uuid == null) {
+            return BASE_URL + "?seed=user";
+        }
+        
+        // UUID를 seed로 사용 (dicebear는 seed 파라미터 사용)
+        // 예: https://api.dicebear.com/9.x/thumbs/svg?seed=123e4567e89b12d3a456426614174000
+        String seed = uuid.toString().replace("-", "");
+        return BASE_URL + "?seed=" + seed;
     }
 }


### PR DESCRIPTION
## 🔍 What
- 프로필 업데이트 시 기존 커스텀 이미지 S3에서 자동 추가, 삭제
- 프로필 이미지 삭제 API 추가 (dice-bear로 복원)
- 회원 탈퇴 시 프로필 이미지 S3에서 삭제
- User 엔티티에 isCustomImage 메서드 추가

## 🧪 How to test
- Postman으로 프로필 업데이트/삭제/회원탈퇴 API 호출
- S3 버킷에서 커스텀 이미지 삭제 여부 확인
- 프로필 이미지가 dice-bear로 복원되는지 확인

## 🔗 Issue
- Closes: #109 

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [x] 최소 1명의 리뷰를 받았나요?