### PR TITLE
[Feat] 시큐리티 설정 통합 및 OAuth2 로그인 흐름 정비

### DIFF
--- a/src/main/java/kr/java/java/domain/auth/controller/AuthController.java
+++ b/src/main/java/kr/java/java/domain/auth/controller/AuthController.java
@@ -30,6 +30,35 @@ public class AuthController {
     @Value("${app.cookie.secure:false}")
     private boolean cookieSecure;
 
+    @GetMapping("/oauth2-token")
+    public ResponseEntity<TokenResponse> getOAuth2Token(HttpServletRequest request) {
+        String refreshToken = getRefreshTokenFromCookie(request);
+
+        if (refreshToken == null) {
+            throw new AuthException(AuthErrorCode.TOKEN_NOT_FOUND);
+        }
+
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        UUID uuid = jwtTokenProvider.getUuidFromToken(refreshToken);
+
+        if (!refreshTokenService.validateRefreshToken(uuid, refreshToken)) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(uuid);
+
+        TokenResponse response = TokenResponse.of(
+                accessToken,
+                refreshToken,
+                jwtTokenProvider.getAccessTokenExpirationInSeconds()
+        );
+
+        return ResponseEntity.ok().body(response);
+    }
+
     @PostMapping("/reissue")
     public ResponseEntity<TokenResponse> reissue(HttpServletRequest request) {
 
@@ -58,8 +87,7 @@ public class AuthController {
         refreshTokenService.saveRefreshToken(uuid, newRefreshToken);
 
         ResponseCookie refreshCookie = createRefreshTokenCookie(newRefreshToken);
-
-        // Access Token은 JSON 응답 본문에 포함 (프론트엔드 메모리 저장용)
+        
         TokenResponse response = TokenResponse.of(
                 newAccessToken,
                 newRefreshToken,
@@ -88,10 +116,12 @@ public class AuthController {
             refreshTokenService.deleteRefreshToken(uuid);
         }
 
-        // Access Token 블랙리스트에 추가
+
         if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
-            long expirationTime = jwtTokenProvider.getAccessTokenExpirationInSeconds();
-            refreshTokenService.addAccessTokenToBlacklist(accessToken, expirationTime);
+            long remainingTime = jwtTokenProvider.getRemainingExpirationTime(accessToken);
+            if (remainingTime > 0) {
+                refreshTokenService.addAccessTokenToBlacklist(accessToken, remainingTime);
+            }
         }
 
         ResponseCookie refreshCookie = deleteRefreshTokenCookie();

--- a/src/main/java/kr/java/java/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/java/java/domain/auth/filter/JwtAuthenticationFilter.java
@@ -38,11 +38,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
 
         try {
-            // Access Token은 Header에서만 추출 (프론트엔드 메모리 저장 방식)
             String token = getJwtFromRequest(request);
 
             if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-                // 블랙리스트 확인 (로그아웃한 토큰 차단)
                 if (refreshTokenService.isAccessTokenBlacklisted(token)) {
                     SecurityContextHolder.clearContext();
                     filterChain.doFilter(request, response);
@@ -67,9 +65,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (Exception e) {
-            // 보안: 인증 실패 시 SecurityContext 명시적으로 정리
             SecurityContextHolder.clearContext();
-            log.error("Could not set user authentication in security context", e);
+            log.error("Security Context에 유저 인증 정보를 설정할 수 없습니다.", e);
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/kr/java/java/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/kr/java/java/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,55 @@
+package kr.java.java.domain.auth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.java.java.domain.auth.jwt.JwtTokenProvider;
+import kr.java.java.domain.auth.service.RefreshTokenService;
+import kr.java.java.domain.auth.security.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    @Value("${app.frontend.url:http://localhost:8081}")
+    private String frontendUrl;
+
+    @Value("${app.cookie.secure:false}")
+    private boolean cookieSecure;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+
+        CustomOAuth2User oauth2User = (CustomOAuth2User) authentication.getPrincipal();
+        UUID uuid = oauth2User.getUuid();
+
+        String refreshToken = jwtTokenProvider.createRefreshToken(uuid);
+        refreshTokenService.saveRefreshToken(uuid, refreshToken);
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
+                .maxAge(7 * 24 * 60 * 60)
+                .path("/")
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
+        String targetUrl = frontendUrl + "/auth/oauth2-callback";
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/kr/java/java/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/java/java/domain/auth/jwt/JwtTokenProvider.java
@@ -98,4 +98,21 @@ public class JwtTokenProvider {
     public long getAccessTokenExpirationInSeconds() {
         return accessTokenExpiration / 1000;
     }
+
+    public long getRemainingExpirationTime(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            long expirationTime = claims.getExpiration().getTime();
+            long currentTime = System.currentTimeMillis();
+
+            return Math.max(0, (expirationTime - currentTime) / 1000);
+        } catch (Exception e) {
+            return 0;
+        }
+    }
 }

--- a/src/main/java/kr/java/java/domain/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/kr/java/java/domain/auth/security/CustomUserDetailsService.java
@@ -19,7 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         if (username == null || username.isEmpty()) {
-            throw new UsernameNotFoundException("Username cannot be null or empty");
+            throw new UsernameNotFoundException("사용자 이름은 비어있을 수 없습니다.");
         }
 
         UUID uuid;
@@ -30,7 +30,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         }
 
         User user = userRepository.findByUuid(uuid)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with UUID: " + uuid));
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다. UUID: " + uuid));
 
         return new CustomUserDetails(
                 user.getUuid(),
@@ -45,12 +45,16 @@ public class CustomUserDetailsService implements UserDetailsService {
         }
 
         User user = userRepository.findByUuid(uuid)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with UUID: " + uuid));
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다. UUID: " + uuid));
 
         return new CustomUserDetails(
                 user.getUuid(),
                 user.getEmail(),
                 user.getRole()
         );
+    }
+    public User findUserByUuid(UUID uuid) {
+        return userRepository.findByUuid(uuid)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다. UUID: " + uuid));
     }
 }

--- a/src/main/java/kr/java/java/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/kr/java/java/domain/auth/service/RefreshTokenService.java
@@ -59,11 +59,6 @@ public class RefreshTokenService {
         return true;
     }
 
-    /**
-     * Access Token을 블랙리스트에 추가 (로그아웃 시 사용)
-     * @param accessToken 블랙리스트에 추가할 Access Token
-     * @param expirationTime 만료 시간 (초 단위)
-     */
     public void addAccessTokenToBlacklist(String accessToken, long expirationTime) {
         if (accessToken == null || accessToken.isEmpty()) {
             throw new AuthException(AuthErrorCode.INVALID_INPUT);
@@ -72,11 +67,6 @@ public class RefreshTokenService {
         redisTemplate.opsForValue().set(key, "blacklisted", expirationTime, TimeUnit.SECONDS);
     }
 
-    /**
-     * Access Token이 블랙리스트에 있는지 확인
-     * @param accessToken 확인할 Access Token
-     * @return 블랙리스트에 있으면 true
-     */
     public boolean isAccessTokenBlacklisted(String accessToken) {
         if (accessToken == null || accessToken.isEmpty()) {
             return false;

--- a/src/main/java/kr/java/java/global/config/SecurityConfig.java
+++ b/src/main/java/kr/java/java/global/config/SecurityConfig.java
@@ -81,7 +81,13 @@ public class SecurityConfig {
                 .headers(headers -> headers
                         .frameOptions(frameOptions -> frameOptions.deny())
                         .xssProtection(xss -> xss.headerValue(XXssProtectionHeaderWriter.HeaderValue.ENABLED_MODE_BLOCK))
-                        .contentSecurityPolicy(csp -> csp.policyDirectives("default-src 'self'; img-src 'self' data: https://api.dicebear.com;"))
+                        .contentSecurityPolicy(csp -> csp
+                                .policyDirectives("default-src 'self'; " +
+                                        "script-src 'self' 'unsafe-inline'; " +
+                                        "img-src 'self' data: https://api.dicebear.com https://*.supabase.co; " +
+                                        "connect-src 'self' https://*.supabase.co; " + // Supabase API 호출 허용
+                                        "style-src 'self' 'unsafe-inline';")
+                        )
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(request -> "OPTIONS".equals(request.getMethod())).permitAll()

--- a/src/main/java/kr/java/java/global/config/SecurityConfig.java
+++ b/src/main/java/kr/java/java/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import kr.java.java.domain.auth.jwt.JwtTokenProvider;
 import kr.java.java.domain.auth.service.AuthService;
 import kr.java.java.domain.auth.service.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -90,7 +91,8 @@ public class SecurityConfig {
                         )
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(request -> "OPTIONS".equals(request.getMethod())).permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers("/css/**", "/js/**", "/images/**", "/favicon.ico").permitAll()
                         .requestMatchers("/").permitAll() // 루트 경로 허용
                         .requestMatchers("/api/auth/**", "/login/**", "/oauth2/**", "/piece/auths/**", "/error").permitAll()
                         .requestMatchers("/piece/spaces/**").permitAll()
@@ -112,10 +114,6 @@ public class SecurityConfig {
                                                  HttpServletResponse response,
                                                  AuthenticationException authException) throws IOException, ServletException {
 
-                                if ("OPTIONS".equals(request.getMethod())) {
-                                    response.setStatus(HttpServletResponse.SC_OK);
-                                    return;
-                                }
 
                                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/kr/java/java/global/config/SecurityConfig.java
+++ b/src/main/java/kr/java/java/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package kr.java.java.global.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.java.java.domain.auth.filter.JwtAuthenticationFilter;
 import kr.java.java.domain.auth.handler.OAuth2AuthenticationFailureHandler;
+import kr.java.java.domain.auth.handler.OAuth2AuthenticationSuccessHandler;
 import kr.java.java.domain.auth.jwt.JwtTokenProvider;
 import kr.java.java.domain.auth.service.AuthService;
 import kr.java.java.domain.auth.service.RefreshTokenService;
@@ -16,9 +17,19 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -35,25 +46,47 @@ public class SecurityConfig {
     private final RefreshTokenService refreshTokenService;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final ObjectMapper objectMapper;
+    private final CorsProperties corsProperties;
 
     @org.springframework.beans.factory.annotation.Value("${app.cookie.secure:false}")
     private boolean cookieSecure;
+
+    @org.springframework.beans.factory.annotation.Value("${app.frontend.url:http://localhost:8081}")
+    private String frontendUrl;
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(corsProperties.getAllowedOrigins());
+        configuration.setAllowedMethods(corsProperties.getAllowedMethods());
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(corsProperties.getMaxAge());
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
-                // 보안 헤더 추가
                 .headers(headers -> headers
                         .frameOptions(frameOptions -> frameOptions.deny())
                         .xssProtection(xss -> xss.headerValue(XXssProtectionHeaderWriter.HeaderValue.ENABLED_MODE_BLOCK))
-                        .contentSecurityPolicy(csp -> csp.policyDirectives("default-src 'self'"))
+                        .contentSecurityPolicy(csp -> csp.policyDirectives("default-src 'self'; img-src 'self' data: https://api.dicebear.com;"))
                 )
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(request -> "OPTIONS".equals(request.getMethod())).permitAll()
+                        .requestMatchers("/").permitAll() // 루트 경로 허용
+                        .requestMatchers("/api/auth/**", "/login/**", "/oauth2/**", "/piece/auths/**", "/error").permitAll()
                         .requestMatchers("/piece/spaces/**").permitAll()
                         .requestMatchers("/piece/portfolios/**").permitAll()
                         .requestMatchers("/piece/reviews/**").permitAll()
@@ -63,11 +96,33 @@ public class SecurityConfig {
                         .requestMatchers("/piece/images/**").permitAll()
                         .requestMatchers("/piece/notifications/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/api/auth/**", "/login/**", "/oauth2/**", "/piece/auths/**", "/error").permitAll()
-                        .requestMatchers("/piece/mypages").authenticated()
-                        .anyRequest().authenticated()
+                        .requestMatchers("/piece/auths/logout").authenticated()
+                        .requestMatchers("/piece/mypages/**").authenticated().anyRequest().authenticated()
                 )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(new AuthenticationEntryPoint() {
+                            @Override
+                            public void commence(HttpServletRequest request,
+                                                 HttpServletResponse response,
+                                                 AuthenticationException authException) throws IOException, ServletException {
 
+                                if ("OPTIONS".equals(request.getMethod())) {
+                                    response.setStatus(HttpServletResponse.SC_OK);
+                                    return;
+                                }
+
+                                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                                response.setCharacterEncoding("UTF-8");
+
+                                Map<String, Object> result = new HashMap<>();
+                                result.put("code", "UNAUTHORIZED");
+                                result.put("message", "인증이 필요합니다.");
+
+                                response.getWriter().write(objectMapper.writeValueAsString(result));
+                            }
+                        })
+                )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 
                 .oauth2Login(oauth2 -> oauth2
@@ -75,40 +130,7 @@ public class SecurityConfig {
                                 userInfo.userService(authService)
                         )
                         .failureHandler(oAuth2AuthenticationFailureHandler)
-                        .successHandler((request, response, authentication) -> {
-
-                            kr.java.java.domain.auth.security.CustomOAuth2User oauth2User =
-                                    (kr.java.java.domain.auth.security.CustomOAuth2User) authentication.getPrincipal();
-
-                            UUID uuid = oauth2User.getUuid();
-
-                            String accessToken = jwtTokenProvider.createAccessToken(uuid);
-                            String refreshToken = jwtTokenProvider.createRefreshToken(uuid);
-
-                            refreshTokenService.saveRefreshToken(uuid, refreshToken);
-
-                            // Refresh Token을 Cookie에 저장 (HttpOnly로 XSS 방지)
-                            ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
-                                    .maxAge(REFRESH_TOKEN_MAX_AGE)
-                                    .path("/")
-                                    .httpOnly(true)
-                                    .secure(cookieSecure)
-                                    .sameSite("Lax")
-                                    .build();
-
-                            response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
-
-                            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-                            response.setCharacterEncoding("UTF-8");
-
-                            // Access Token을 JSON 응답 본문에 포함 (프론트엔드 메모리 저장용)
-                            Map<String, Object> result = new HashMap<>();
-                            result.put("accessToken", accessToken);
-                            result.put("uuid", uuid.toString());
-                            result.put("message", "로그인 성공");
-
-                            response.getWriter().write(objectMapper.writeValueAsString(result));
-                        })
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
                 );
 
         return http.build();

--- a/src/main/java/kr/java/java/global/config/WebConfig.java
+++ b/src/main/java/kr/java/java/global/config/WebConfig.java
@@ -11,16 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 public class WebConfig implements WebMvcConfigurer {
 
 
-    private final CorsProperties corsProperties;
-
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry
-                .addMapping("/piece/**")
-                .allowedOrigins(corsProperties.getAllowedOrigins().toArray(new String[0]))
-                .allowedMethods(corsProperties.getAllowedMethods().toArray(new String[0]))
-                .allowedHeaders("*")
-                .allowCredentials(true)
-                .maxAge(corsProperties.getMaxAge());
     }
 }


### PR DESCRIPTION
## 🔍 What
- 소셜 로그인 성공 에러 핸들러 추가, SecurityConfig 고도화
- 소셜 로그인시 토큰, uuid 저장 로직 수정
- cors 설정 통합(WebConfig -> SecurityConfig로 이동)
- 외부 API 허용을 위한 csp 설정 추가(dice bear, supabase)
- getRemainingExpirationTime 도입으로 redis TTL 설정 추가

## 🧪 How to test
- 소셜 로그인 테스트: 카카오/구글 로그인 성공 시 브라우저 쿠키에 refreshToken이 HttpOnly 상태로 정상 저장되는지 확인
- 토큰 재발급(Reissue) 테스트: 기존 Refresh Token으로 Access Token 재발급 요청 시, 새로운 토큰이 발급되며 기존 토큰이 무효화되는지 확인 (RTR 검증)
- 로그아웃 및 블랙리스트 테스트: 로그아웃 직후 기존에 사용하던 Access Token으로 API 호출 시 401 Unauthorized 또는 거부 응답이 오는지 확인 (Redis 블랙리스트 검증)
- CSP 정책 테스트: 브라우저 콘솔(F12)에서 Supabase나 DiceBear 이미지 호출 시 CSP 위반 에러가 발생하지 않는지 확인

## 🔗 Issue
- Closes: #117 

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?