### PR TITLE
[Fix] 공간주의 매칭 수락 시 isHost의 정의 수정

### DIFF
--- a/src/main/java/kr/java/java/domain/matching/service/MatchingService.java
+++ b/src/main/java/kr/java/java/domain/matching/service/MatchingService.java
@@ -285,3 +285,4 @@ public class MatchingService {
         }
     }
 }
+

--- a/src/main/java/kr/java/java/domain/matching/service/MatchingService.java
+++ b/src/main/java/kr/java/java/domain/matching/service/MatchingService.java
@@ -167,7 +167,7 @@ public class MatchingService {
 
         matching.updateStatus(MatchStatus.ONGOING);
 
-        boolean isHost = matching.getReceiver().getId().equals(userId);
+        boolean isHost = matching.getSpace().getUser().getId().equals(userId);
 
         if(isHost){
             autoRejectOverlappingMatchings(matching);


### PR DESCRIPTION
## 🔍 What
- 공간주의 매칭 수락 시 isHost의 정의 수정

## 🧪 How to test
- 공간주의 매칭 수락 시 다른 매칭들의 거절 확인(조건에 부합하는)

## 🔗 Issue
- Closes: #120 

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [x] 최소 1명의 리뷰를 받았나요?