### PR TITLE
[Feat] 이미지 수정 구현

### DIFF
--- a/src/main/java/kr/java/java/domain/image/controller/ImageController.java
+++ b/src/main/java/kr/java/java/domain/image/controller/ImageController.java
@@ -53,4 +53,17 @@ public class ImageController {
         imageService.deleteSingleImage(imageId);
         return ResponseEntity.noContent().build();
     }
+
+    @PatchMapping("/{targetType}/{targetId}")
+    public ResponseEntity<Void> updateImages(
+            @PathVariable TargetType targetType,
+            @PathVariable Long targetId,
+            @RequestParam(value = "remainImageIds", required = false) List<Long> remainImageIds,
+            @RequestPart(value = "newFiles", required = false) List<MultipartFile> newFiles
+    ) throws IOException {
+
+        imageService.updateImages(targetType, targetId, remainImageIds, newFiles);
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/kr/java/java/domain/image/dto/ImageUpdateRequest.java
+++ b/src/main/java/kr/java/java/domain/image/dto/ImageUpdateRequest.java
@@ -1,0 +1,11 @@
+package kr.java.java.domain.image.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record ImageUpdateRequest(
+        Long id,
+        String fileUrl,
+        Integer sortOrder,
+        MultipartFile file
+) {
+}

--- a/src/main/java/kr/java/java/domain/image/entity/Image.java
+++ b/src/main/java/kr/java/java/domain/image/entity/Image.java
@@ -63,4 +63,8 @@ public class Image {
         this.space = space;
         this.portfolio = portfolio;
     }
+
+    public void updateSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
 }

--- a/src/main/java/kr/java/java/domain/image/service/ImageService.java
+++ b/src/main/java/kr/java/java/domain/image/service/ImageService.java
@@ -1,5 +1,6 @@
 package kr.java.java.domain.image.service;
 
+import jakarta.transaction.Transactional;
 import kr.java.java.domain.image.dto.ImageResponse;
 import kr.java.java.domain.image.entity.Image;
 import kr.java.java.domain.image.enums.ImageDomain;
@@ -113,6 +114,61 @@ public class ImageService {
         return images.stream()
                 .map(ImageResponse::from)
                 .toList();
+    }
+
+    @Transactional
+    public void updateImages(TargetType targetType, Long targetId, List<Long> remainImageIds, List<MultipartFile> newFiles) throws IOException{
+        List<Image> currentImages = switch(targetType) {
+            case REVIEW -> imageRepository.findAllByReviewIdOrderBySortOrderAsc(targetId);
+            case SPACE -> imageRepository.findAllBySpaceIdOrderBySortOrderAsc(targetId);
+            case PORTFOLIO -> imageRepository.findAllByPortfolioIdOrderBySortOrderAsc(targetId);
+        };
+
+        // 삭제할 이미지들 추출
+        List<Image> toDelete = currentImages.stream()
+                .filter(img -> !remainImageIds.contains(img.getId()))
+                .toList();
+
+        // TODO 한 번에 삭제할 수 있도록 추후 작성
+        for(Image image : toDelete) {
+            deleteSingleImage(image.getId());
+        }
+
+        int newFileIndex = 0;
+        for(int i=0; i<remainImageIds.size(); i++) {
+            Long imageId = remainImageIds.get(i);
+            int targetSortOrder = i+1;
+
+            // 원래 있던 이미지라면
+            if(imageId != null){
+                // TODO 추후 이미지 한 번에 가져와 루프에서 꺼내기
+                imageRepository.findById(imageId).ifPresent(img ->{
+                    img.updateSortOrder(targetSortOrder);
+                });
+            } else{
+                if(newFiles != null && newFileIndex < newFiles.size()) {
+                    MultipartFile file = newFiles.get(newFileIndex++);
+                    if(!file.isEmpty()) {
+                        uploadAndSaveSingleImage(file, targetType, targetId, targetSortOrder);
+                    }
+                }
+            }
+        }
+    }
+
+    private void uploadAndSaveSingleImage(MultipartFile file, TargetType targetType, Long targetId, int sortOrder) throws IOException {
+        String fileName = FileUtil.createFileName(file.getOriginalFilename());
+
+        s3Client.putObject(PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .contentType(file.getContentType())
+                .build(), RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+        String fileUrl = String.format("%s/storage/v1/object/public/%s/%s", supabaseUrl, bucket, fileName);
+
+        Image image = createEntityByTargetType(targetType, targetId, fileUrl, sortOrder);
+        imageRepository.save(image);
     }
 
     public void deleteSingleImage(Long imageId) {


### PR DESCRIPTION
## 🔍 What
- 공간/포트폴리오/리뷰에서의 이미지 수정

## 🧪 How to test
- Postman을 사용하여 url을 작성
- Body의 form-data를 사용
- Key에 remainImageIds를, Text 형식으로, Value에 이미지의 id를 작성(유지되어야 할 이미지)
- Key에 newFiles를, File 형식으로, Value에 이미지 파일을 업로드

## Coment
- Image 도메인 Controller의 사용은 추후 확정짓도록 하겠습니다.

## 🔗 Issue
- Closes: #119 
---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?