### PR TITLE
[Feat] 포트폴리오 이미지 저장 연동

### DIFF
--- a/src/main/java/kr/java/java/domain/portfolio/controller/PortfolioController.java
+++ b/src/main/java/kr/java/java/domain/portfolio/controller/PortfolioController.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -18,10 +19,11 @@ public class PortfolioController {
     private final PortfolioService portfolioService;
 
     @PostMapping
-    public ResponseEntity<Void> createPortfolio(@RequestBody PortfolioRequest request, Long loginUserId){
+    public ResponseEntity<Void> createPortfolio( @RequestPart("request") PortfolioRequest request, Long loginUserId,
+                                                 @RequestPart(value = "images", required = false) List<MultipartFile> images){
         log.info("포트폴리오 등록 시도 - UserId : {}",loginUserId);
         //TODO 인증이 완성되지 않아서 임시 테스트용으로 더미데이터를 직접 삽입
-        portfolioService.createPortfolio(request,1L);
+        portfolioService.createPortfolio(request,1L,images);
         //TODO 응답 dto를 생성시 응답객체를 반환하도록 수정 예정
         return  ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/kr/java/java/domain/portfolio/exception/ImageNotUploadException.java
+++ b/src/main/java/kr/java/java/domain/portfolio/exception/ImageNotUploadException.java
@@ -1,0 +1,7 @@
+package kr.java.java.domain.portfolio.exception;
+
+public class ImageNotUploadException extends RuntimeException {
+    public ImageNotUploadException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/java/java/domain/portfolio/exception/PortfolioDeleteException.java
+++ b/src/main/java/kr/java/java/domain/portfolio/exception/PortfolioDeleteException.java
@@ -1,0 +1,7 @@
+package kr.java.java.domain.portfolio.exception;
+
+public class PortfolioDeleteException extends RuntimeException {
+    public PortfolioDeleteException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/java/java/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/kr/java/java/domain/portfolio/service/PortfolioService.java
@@ -1,10 +1,14 @@
 package kr.java.java.domain.portfolio.service;
 
 
+import kr.java.java.domain.image.enums.TargetType;
+import kr.java.java.domain.image.service.ImageService;
 import kr.java.java.domain.portfolio.dto.*;
 import kr.java.java.domain.portfolio.entity.Portfolio;
 import kr.java.java.domain.portfolio.exception.DuplicatePortfolioException;
+import kr.java.java.domain.portfolio.exception.ImageNotUploadException;
 import kr.java.java.domain.portfolio.exception.NotFoundPortfolioException;
+import kr.java.java.domain.portfolio.exception.PortfolioDeleteException;
 import kr.java.java.domain.portfolio.repository.PortfolioRepository;
 import kr.java.java.domain.space.exception.NotFoundUserException;
 import kr.java.java.domain.space.exception.UnAuthorizedException;
@@ -14,7 +18,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -23,9 +29,10 @@ import java.util.List;
 public class PortfolioService {
     private final PortfolioRepository portfolioRepository;
     private final UserRepository userRepository;
+    private final ImageService imageService;
 
     @Transactional
-    public void createPortfolio(PortfolioRequest portfolioRequest, Long loginUserId){
+    public void createPortfolio(PortfolioRequest portfolioRequest, Long loginUserId, List<MultipartFile> images){
         if (portfolioRepository.existsByBrandNameAndTitle(portfolioRequest.brandName(), portfolioRequest.title())) {
             log.error("동일한 포트폴리오가 존재합니다.");
             throw new DuplicatePortfolioException("동일한 포트폴리오가 존재합니다.");
@@ -33,8 +40,19 @@ public class PortfolioService {
 
         // TODO 로그인한 유저 권한검증 추가예정
         User user = userRepository.getReferenceById(loginUserId);
+
         Portfolio portfolio = portfolioRequest.toEntity(user);
         portfolioRepository.save(portfolio);
+
+        if (images != null && !images.isEmpty()) {
+            try {
+                // TargetType.SPACE와 방금 만든 space.getId()를 넘김
+                imageService.uploadImage(images, TargetType.SPACE, portfolio.getId());
+            } catch (IOException e) {
+                log.error("이미지 업로드 실패", e);
+                throw new ImageNotUploadException("이미지 업로드 중 오류가 발생했습니다.");
+            }
+        }
     }
 
     @Transactional(readOnly = true)
@@ -74,7 +92,7 @@ public class PortfolioService {
             portfolioRepository.delete(portfolio);
         } catch (Exception e) {
             log.error("포트폴리오 삭제 실패 (참조 데이터 존재)");
-            throw new RuntimeException("현재 예약 내역이 있어 삭제할 수 없습니다.");
+            throw new PortfolioDeleteException("현재 예약 내역이 있어 삭제할 수 없습니다.");
         }
     }
 


### PR DESCRIPTION
## 🔍 What
- 포트폴리오 저장시 이미지도 같이 저장하도록 로직 수정


## 🧪 How to test
- PostMan으로 formData를 선택 후 text타입의 임시 데이터를 넣은 후 context-type을 application/json으로 설정 후 사진과 같이 등록이되는지 테스트
- 컨텍스트 타입 설정하는거 빼먹지 않게 주의 바람

## 🔗 Issue
- Closes: #125
- Refs: #124

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?