### PR TITLE
[Feat] 회원 탈퇴 로직 추가 및 알림 삭제 구현

### DIFF
--- a/src/main/java/kr/java/java/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/kr/java/java/domain/notification/repository/NotificationRepository.java
@@ -3,6 +3,7 @@ package kr.java.java.domain.notification.repository;
 import kr.java.java.domain.notification.entity.Notification;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -27,4 +28,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findReadNotifications(@Param("userId") Long userId,
                                              @Param("lastId") Long lastId,
                                              Pageable pageable);
+
+    // 사용자별 알림 삭제
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Notification n WHERE n.receiverId = :receiverId")
+    void deleteByReceiverId(@Param("receiverId") Long receiverId);
 }

--- a/src/main/java/kr/java/java/domain/user/service/MypageService.java
+++ b/src/main/java/kr/java/java/domain/user/service/MypageService.java
@@ -10,6 +10,7 @@ import kr.java.java.domain.image.service.ImageService;
 import kr.java.java.domain.matching.entity.Matching;
 import kr.java.java.domain.matching.enums.MatchStatus;
 import kr.java.java.domain.matching.repository.MatchingRepository;
+import kr.java.java.domain.notification.repository.NotificationRepository;
 import kr.java.java.domain.notification.service.NotificationService;
 import kr.java.java.domain.portfolio.repository.PortfolioRepository;
 import kr.java.java.domain.review.repository.ReviewRepository;
@@ -29,7 +30,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -48,6 +48,7 @@ public class MypageService {
     private final FavoriteRepository favoriteRepository;
     private final RefreshTokenService refreshTokenService;
     private final ImageService imageService;
+    private final NotificationRepository notificationRepository;
 
     // 마이페이지 메인
     public MypageResponse getMypage(UUID uuid) {
@@ -128,8 +129,18 @@ public class MypageService {
             imageService.deleteProfileImage(user.getProfileImageUrl());
         }
 
-        // TODO: Review, Portfolio, Space soft delete (벌크 업데이트)
-        // TODO: 알림 수동 삭제
+        // Review, Portfolio, Space soft delete (벌크 업데이트)
+        LocalDateTime deletedAt = LocalDateTime.now();
+        int deletedReviews = reviewRepository.softDeleteAllByUserId(userId, deletedAt);
+        int deletedPortfolios = portfolioRepository.softDeleteAllByUserId(userId, deletedAt);
+        int deletedSpaces = spaceRepository.softDeleteAllByMemberId(userId, deletedAt);
+        
+        log.info("회원 탈퇴 - Soft Delete 완료: Review {}건, Portfolio {}건, Space {}건", 
+                deletedReviews, deletedPortfolios, deletedSpaces);
+
+        // 알림 수동 삭제
+        notificationRepository.deleteByReceiverId(userId);
+        log.info("회원 탈퇴 - 알림 삭제 완료: uuid {}, userId {}", uuid, userId);
 
         refreshTokenService.deleteRefreshToken(uuid);
 


### PR DESCRIPTION
## 🔍 What
- 회원 탈퇴 시 데이터 소프트 딜리트 로직 구현

## 🧪 How to test
- 회원 탈퇴시 데이터가 정상적으로 삭제됩니다.

## 🔗 Issue
- Closes: #138 

---
### ✅ 체크리스트
- base가 **develop**으로 설정되었나요?
- 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- 최소 1명의 리뷰를 받았나요?