### PR TITLE
[Feat] S3 업로드 시 domain/ 경로처리, S3와 spaceImage 트랜잭션 분리(delete), spaceImage softdelete

### DIFF
--- a/src/main/java/kr/java/java/domain/image/entity/BaseImage.java
+++ b/src/main/java/kr/java/java/domain/image/entity/BaseImage.java
@@ -28,6 +28,9 @@ public abstract class BaseImage {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     protected BaseImage(String fileUrl, Integer sortOrder) {
         this.fileUrl = fileUrl;
         this.sortOrder = sortOrder;

--- a/src/main/java/kr/java/java/domain/image/entity/SpaceImage.java
+++ b/src/main/java/kr/java/java/domain/image/entity/SpaceImage.java
@@ -6,11 +6,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @Table(name = "space_images")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
 public class SpaceImage extends BaseImage{
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "space_id")

--- a/src/main/java/kr/java/java/domain/image/repository/SpaceImageRepository.java
+++ b/src/main/java/kr/java/java/domain/image/repository/SpaceImageRepository.java
@@ -23,4 +23,8 @@ public interface SpaceImageRepository extends JpaRepository<SpaceImage, Long> {
     @Query("UPDATE SpaceImage si SET si.deletedAt = NOW() " +
             "WHERE si.space.id = :spaceId AND si.deletedAt IS NULL")
     void softDeleteAllBySpaceId(@Param("spaceId") Long spaceId);
+
+    @Modifying
+    @Query("UPDATE SpaceImage si SET si.deletedAt = NOW() WHERE si.id IN :ids")
+    void softDeleteByIds(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/kr/java/java/domain/image/repository/SpaceImageRepository.java
+++ b/src/main/java/kr/java/java/domain/image/repository/SpaceImageRepository.java
@@ -3,6 +3,7 @@ package kr.java.java.domain.image.repository;
 import kr.java.java.domain.image.entity.ReviewImage;
 import kr.java.java.domain.image.entity.SpaceImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,4 +18,9 @@ public interface SpaceImageRepository extends JpaRepository<SpaceImage, Long> {
 
     @Query("SELECT si FROM SpaceImage si WHERE si.space.id IN :spaceIds AND si.sortOrder = 1")
     List<SpaceImage> findThumbnailsBySpaceIds(@Param("spaceIds") List<Long> spaceIds);
+
+    @Modifying(clearAutomatically = true) // 벌크 연산 후 영속성 컨텍스트 초기화
+    @Query("UPDATE SpaceImage si SET si.deletedAt = NOW() " +
+            "WHERE si.space.id = :spaceId AND si.deletedAt IS NULL")
+    void softDeleteAllBySpaceId(@Param("spaceId") Long spaceId);
 }

--- a/src/main/java/kr/java/java/domain/image/service/PortfolioImageService.java
+++ b/src/main/java/kr/java/java/domain/image/service/PortfolioImageService.java
@@ -43,7 +43,7 @@ public class PortfolioImageService {
             MultipartFile file = files.get(i);
             if (file.isEmpty()) continue;
 
-            String fileUrl = s3StorageService.uploadFile(file);
+            String fileUrl = s3StorageService.uploadFile(file, "portfolios");
 
             PortfolioImage portfolioImage = PortfolioImage.builder()
                     .fileUrl(fileUrl)
@@ -87,7 +87,7 @@ public class PortfolioImageService {
     private void uploadSingleImage(Long portfolioId, MultipartFile file, int sortOrder) {
         if (file.isEmpty()) return;
         Portfolio portfolio = portfolioRepository.findById(portfolioId).orElseThrow();
-        String url = s3StorageService.uploadFile(file);
+        String url = s3StorageService.uploadFile(file, "prtfolios");
         portfolioImageRepository.save(PortfolioImage.builder()
                 .fileUrl(url)
                 .sortOrder(sortOrder)

--- a/src/main/java/kr/java/java/domain/image/service/ReviewImageService.java
+++ b/src/main/java/kr/java/java/domain/image/service/ReviewImageService.java
@@ -57,7 +57,7 @@ public class ReviewImageService {
             MultipartFile file = files.get(i);
             if (file.isEmpty()) continue;
 
-            String url = s3StorageService.uploadFile(file);
+            String url = s3StorageService.uploadFile(file, "reviews");
             reviewImageRepository.save(ReviewImage.builder()
                     .fileUrl(url)
                     .sortOrder(i + 1)
@@ -98,7 +98,7 @@ public class ReviewImageService {
     private void uploadSingleImage(Long reviewId, MultipartFile file, int sortOrder) {
         if (file.isEmpty()) return;
         Review review = reviewRepository.findById(reviewId).orElseThrow();
-        String url = s3StorageService.uploadFile(file);
+        String url = s3StorageService.uploadFile(file, "reviews");
         reviewImageRepository.save(ReviewImage.builder()
                 .fileUrl(url)
                 .sortOrder(sortOrder)

--- a/src/main/java/kr/java/java/domain/image/service/S3StorageService.java
+++ b/src/main/java/kr/java/java/domain/image/service/S3StorageService.java
@@ -30,35 +30,44 @@ public class S3StorageService {
 
     private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png", "gif", "webp");
 
-    public String uploadFile(MultipartFile file){
+    public String uploadFile(MultipartFile file, String domain){
         if (file == null || file.isEmpty()) return null;
 
         validateImageFile(file);
 
         String fileName = FileUtil.createFileName(file.getOriginalFilename());
+        String key = domain + "/" + fileName;
+
         try {
             s3Client.putObject(PutObjectRequest.builder()
                     .bucket(bucket)
-                    .key(fileName)
+                    .key(key)
                     .contentType(file.getContentType())
                     .build(), RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
         } catch (Exception e) {
-            log.error("이미지 업로드 실패: {}", e.getMessage(), e);
             throw new ImageException(ImageErrorCode.UPLOAD_FAILED);
         }
 
-        String fileUrl = String.format("%s/storage/v1/object/public/%s/%s", supabaseUrl, bucket, fileName);
+        String fileUrl = String.format("%s/storage/v1/object/public/%s/%s", supabaseUrl, bucket, key);
 
         return fileUrl;
     }
 
     public void deleteFile(String fileUrl) {
-        String fileName = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
-        s3Client.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(fileName).build());
+        String searchString = bucket + "/";
+        int bucketIndex = fileUrl.lastIndexOf(searchString);
+
+        if(bucketIndex != -1){
+            String key = fileUrl.substring(bucketIndex + searchString.length());
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build());
+        }
     }
 
     public String uploadProfileImage(MultipartFile file){
-        return uploadFile(file);
+        return uploadFile(file, "profiles");
     }
 
     private void validateImageFile(MultipartFile file) {

--- a/src/main/java/kr/java/java/domain/image/service/SpaceImageService.java
+++ b/src/main/java/kr/java/java/domain/image/service/SpaceImageService.java
@@ -86,7 +86,8 @@ public class SpaceImageService {
                 .filter(img -> remainImageIds == null || !remainImageIds.contains(img.getId())).toList();
 
         if (!imagesToRemove.isEmpty()) {
-            spaceImageRepository.deleteAll(imagesToRemove);
+            List<Long> idsToDelete = imagesToRemove.stream().map(SpaceImage::getId).toList();
+            spaceImageRepository.softDeleteByIds(idsToDelete);
         }
 
         Map<Long, SpaceImage> imageMap = currentImages.stream()

--- a/src/main/java/kr/java/java/domain/image/service/SpaceImageService.java
+++ b/src/main/java/kr/java/java/domain/image/service/SpaceImageService.java
@@ -65,7 +65,7 @@ public class SpaceImageService {
             MultipartFile file = files.get(i);
             if (file.isEmpty()) continue;
 
-            String fileUrl = s3StorageService.uploadFile(file);
+            String fileUrl = s3StorageService.uploadFile(file, "spaces");
 
             SpaceImage spaceImage = SpaceImage.builder()
                     .fileUrl(fileUrl)
@@ -110,7 +110,7 @@ public class SpaceImageService {
     private void uploadSingleImage(Long spaceId, MultipartFile file, int sortOrder) {
         if (file.isEmpty()) return;
         Space space = spaceRepository.findById(spaceId).orElseThrow();
-        String url = s3StorageService.uploadFile(file);
+        String url = s3StorageService.uploadFile(file, "spaces");
         spaceImageRepository.save(SpaceImage.builder()
                 .fileUrl(url)
                 .sortOrder(sortOrder)

--- a/src/main/java/kr/java/java/domain/image/service/SpaceImageService.java
+++ b/src/main/java/kr/java/java/domain/image/service/SpaceImageService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.awt.*;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -77,44 +78,48 @@ public class SpaceImageService {
         }
     }
 
+    @Transactional
     public void updateImages(Long spaceId, List<Long> remainImageIds, List<MultipartFile> newFiles) {
         List<SpaceImage> currentImages = spaceImageRepository.findAllBySpaceIdOrderBySortOrderAsc(spaceId);
 
-        // 삭제 로직
-        currentImages.stream()
-                .filter(img -> remainImageIds == null || !remainImageIds.contains(img.getId()))
-                .forEach(img -> {
-                    s3StorageService.deleteFile(img.getFileUrl());
-                    spaceImageRepository.delete(img);
-                });
+        List<SpaceImage> imagesToRemove = currentImages.stream()
+                .filter(img -> remainImageIds == null || !remainImageIds.contains(img.getId())).toList();
+
+        if (!imagesToRemove.isEmpty()) {
+            spaceImageRepository.deleteAll(imagesToRemove);
+        }
+
+        Map<Long, SpaceImage> imageMap = currentImages.stream()
+                .collect(Collectors.toMap(SpaceImage::getId, img -> img));
 
         int currentSortOrder = 1;
-
-        for (Long imageId : remainImageIds) {
-            SpaceImage img = spaceImageRepository.findById(imageId)
-                    .orElse(null);
-            if (img != null) {
-                img.updateSortOrder(currentSortOrder++);
+        if (remainImageIds != null) {
+            for (Long imageId : remainImageIds) {
+                SpaceImage img = imageMap.get(imageId);
+                if (img != null) {
+                    img.updateSortOrder(currentSortOrder++);
+                }
             }
         }
 
         if (newFiles != null && !newFiles.isEmpty()) {
+            Space space = spaceRepository.findById(spaceId)
+                    .orElseThrow(() -> new NotFoundSpaceException("해당 공간을 찾을 수 없습니다."));
+
+            List<SpaceImage> newImages = new ArrayList<>();
             for (MultipartFile file : newFiles) {
-                if (!file.isEmpty()) {
-                    uploadSingleImage(spaceId, file, currentSortOrder++);
+                if (file != null && !file.isEmpty()) {
+                    // S3 업로드 시 도메인(spaces) 지정
+                    String url = s3StorageService.uploadFile(file, "spaces");
+
+                    newImages.add(SpaceImage.builder()
+                            .fileUrl(url)
+                            .sortOrder(currentSortOrder++)
+                            .space(space)
+                            .build());
                 }
             }
+            spaceImageRepository.saveAll(newImages);
         }
-    }
-
-    private void uploadSingleImage(Long spaceId, MultipartFile file, int sortOrder) {
-        if (file.isEmpty()) return;
-        Space space = spaceRepository.findById(spaceId).orElseThrow();
-        String url = s3StorageService.uploadFile(file, "spaces");
-        spaceImageRepository.save(SpaceImage.builder()
-                .fileUrl(url)
-                .sortOrder(sortOrder)
-                .space(space)
-                .build());
     }
 }

--- a/src/main/java/kr/java/java/domain/space/entity/Space.java
+++ b/src/main/java/kr/java/java/domain/space/entity/Space.java
@@ -1,6 +1,7 @@
 package kr.java.java.domain.space.entity;
 
 import jakarta.persistence.*;
+import kr.java.java.domain.image.entity.SpaceImage;
 import kr.java.java.domain.matching.entity.Matching;
 import kr.java.java.domain.space.dto.SpaceUpdateRequest;
 import kr.java.java.domain.space.enums.SpaceCategory;
@@ -75,6 +76,9 @@ public class Space {
 
     @OneToMany(mappedBy = "space")
     private List<Matching> matchings = new ArrayList<>();
+
+    @OneToMany(mappedBy = "space")
+    private List<SpaceImage> images = new ArrayList<>();
 
     @Builder
     public Space(String title, String description, SpaceCategory category, String address, String detailAddress, BigDecimal latitude, BigDecimal longitude, Integer pricePerMonth,LocalDateTime createdAt,User user){

--- a/src/main/java/kr/java/java/domain/space/service/SpaceService.java
+++ b/src/main/java/kr/java/java/domain/space/service/SpaceService.java
@@ -3,6 +3,7 @@ package kr.java.java.domain.space.service;
 import kr.java.java.domain.auth.exception.AuthErrorCode;
 import kr.java.java.domain.auth.exception.AuthException;
 import kr.java.java.domain.image.dto.ImageResponse;
+import kr.java.java.domain.image.repository.SpaceImageRepository;
 import kr.java.java.domain.image.service.SpaceImageService;
 import kr.java.java.domain.matching.dto.MySpaceSummary;
 import kr.java.java.domain.review.dto.ReviewSummary;
@@ -36,6 +37,7 @@ public class SpaceService {
     private final SpaceImageService spaceImageService;
     private final ReviewService reviewService;
     private final AiRecommendationRepository aiRecommendationRepository;
+    private final SpaceImageRepository spaceImageRepository;
 
     @Transactional
     public void createSpace(SpaceRequest spaceRequest, List<MultipartFile> images, UUID userId) {
@@ -108,6 +110,7 @@ public class SpaceService {
         }
 
         try {
+            spaceImageRepository.softDeleteAllBySpaceId(id);
             spaceRepository.delete(space);
 
         } catch (DataIntegrityViolationException e) {


### PR DESCRIPTION
## 🔍 What
- S3 업로드 시 domain/ 경로처리
- S3와 spaceImage 트랜잭션 분리(delete)
- spaceImage softdelete

## 🧪 How to test
- 이미지 업로드 시 supabase bucket 경로 확인
- 공간 이미지 수정 및 공간 삭제 시 space_images 상태 확인(DB 확인)

## 🔗 Issue
- Closes: #218 

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?